### PR TITLE
feat: カレンダーページをタイムライン＋ガントビューにリデザイン

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,110 @@
+// app/calendar/page.tsx
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { CalendarIcon, LayoutList, GanttChartSquare } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { SchoolSidebar } from '@/components/calendar/SchoolSidebar'
+import { TimelineView } from '@/components/calendar/TimelineView'
+import { GanttView } from '@/components/calendar/GanttView'
+import { ConflictBanner } from '@/components/calendar/ConflictBanner'
+import { MOCK_BOOKMARKS } from '@/components/calendar/mockData'
+import type { ViewType } from '@/components/calendar/types'
+
+export default function CalendarPage() {
+  const [activeView, setActiveView] = useState<ViewType>('timeline')
+  const [selectedSchoolId, setSelectedSchoolId] = useState<string | null>(null)
+
+  return (
+    <div className="min-h-screen bg-bg-main py-10 px-6">
+      <div className="max-w-6xl mx-auto">
+
+        {/* ヘッダー */}
+        <header className="mb-8 flex flex-col sm:flex-row justify-between items-start sm:items-end gap-4">
+          <div>
+            <div className="inline-flex items-center gap-2 bg-primary/5 text-primary rounded-full px-4 py-2 text-sm font-bold mb-4">
+              <CalendarIcon className="w-4 h-4" />
+              <span>マイカレンダー</span>
+            </div>
+            <h1 className="text-4xl font-serif text-text-main">受験スケジュール</h1>
+            <p className="text-text-sub mt-2">志望校の日程を確認し、重複をチェックしましょう。</p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {/* ビュー切替ボタン */}
+            <div className="flex items-center bg-bg-card border border-border-custom rounded-xl p-1 gap-1">
+              <button
+                onClick={() => setActiveView('timeline')}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                  activeView === 'timeline'
+                    ? 'bg-primary text-white shadow-sm'
+                    : 'text-text-sub hover:text-text-main'
+                }`}
+              >
+                <LayoutList className="w-4 h-4" />
+                Timeline
+              </button>
+              <button
+                onClick={() => setActiveView('gantt')}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                  activeView === 'gantt'
+                    ? 'bg-primary text-white shadow-sm'
+                    : 'text-text-sub hover:text-text-main'
+                }`}
+              >
+                <GanttChartSquare className="w-4 h-4" />
+                Gantt
+              </button>
+            </div>
+
+            <Link href="/dashboard">
+              <Button className="bg-primary text-white rounded-xl font-bold px-5 h-10 shadow-md hover:opacity-90 transition-all">
+                学校を追加する
+              </Button>
+            </Link>
+          </div>
+        </header>
+
+        {/* 重複警告バナー */}
+        <ConflictBanner bookmarks={MOCK_BOOKMARKS} />
+
+        {/* メインコンテンツ: サイドバー + ビューエリア */}
+        {MOCK_BOOKMARKS.length === 0 ? (
+          <div className="text-center py-32 bg-bg-card rounded-3xl border border-dashed border-border-custom">
+            <CalendarIcon className="w-16 h-16 text-text-muted mx-auto mb-6" />
+            <h3 className="text-xl font-serif text-text-main">カレンダーは空です</h3>
+            <p className="text-text-sub mt-2 mb-8">志望校を追加してスケジュールを管理しましょう。</p>
+            <Link href="/dashboard">
+              <Button className="bg-primary text-white rounded-xl font-bold px-8 h-12 shadow-lg">
+                学校を探す
+              </Button>
+            </Link>
+          </div>
+        ) : (
+          <div className="flex gap-6 items-start">
+            <SchoolSidebar
+              bookmarks={MOCK_BOOKMARKS}
+              selectedId={selectedSchoolId}
+              onSelect={setSelectedSchoolId}
+            />
+
+            <div className="flex-1 bg-bg-card border border-border-custom rounded-2xl p-6 min-h-[600px] flex flex-col">
+              {activeView === 'timeline' ? (
+                <TimelineView
+                  bookmarks={MOCK_BOOKMARKS}
+                  selectedId={selectedSchoolId}
+                />
+              ) : (
+                <GanttView
+                  bookmarks={MOCK_BOOKMARKS}
+                  selectedId={selectedSchoolId}
+                />
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -82,7 +82,7 @@ export default function CalendarPage() {
             </Link>
           </div>
         ) : (
-          <div className="flex gap-6 items-start">
+          <div className="flex flex-col lg:flex-row gap-6 items-start">
             <SchoolSidebar
               bookmarks={MOCK_BOOKMARKS}
               selectedId={selectedSchoolId}

--- a/components/calendar/ConflictBanner.tsx
+++ b/components/calendar/ConflictBanner.tsx
@@ -1,0 +1,35 @@
+// components/calendar/ConflictBanner.tsx
+import { AlertTriangle } from 'lucide-react'
+import { Bookmark } from './types'
+
+interface ConflictBannerProps {
+  bookmarks: Bookmark[]
+}
+
+// exam_date が同日の bookmark が2件以上ある場合に警告表示
+export function ConflictBanner({ bookmarks }: ConflictBannerProps) {
+  const dateCounts = bookmarks.reduce<Record<string, number>>((acc, b) => {
+    acc[b.schedule.exam_date] = (acc[b.schedule.exam_date] ?? 0) + 1
+    return acc
+  }, {})
+
+  const conflictDates = Object.entries(dateCounts)
+    .filter(([, count]) => count > 1)
+    .map(([date]) => date)
+
+  if (conflictDates.length === 0) return null
+
+  return (
+    <div className="mb-6 bg-destructive/10 border border-destructive/20 rounded-2xl p-5 flex items-start gap-4">
+      <div className="bg-destructive text-white p-2 rounded-xl shrink-0">
+        <AlertTriangle className="w-5 h-5" />
+      </div>
+      <div>
+        <h3 className="text-destructive font-bold text-base">試験日の重複が検出されました！</h3>
+        <p className="text-text-main/80 text-sm mt-1">
+          {conflictDates.join('、')} に複数の試験が重複しています。スケジュールを再確認してください。
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/calendar/ConflictBanner.tsx
+++ b/components/calendar/ConflictBanner.tsx
@@ -1,15 +1,10 @@
 // components/calendar/ConflictBanner.tsx
 import { AlertTriangle } from 'lucide-react'
 import { Bookmark } from './types'
+import { formatDate } from './utils'
 
 interface ConflictBannerProps {
   bookmarks: Bookmark[]
-}
-
-// YYYY-MM-DD を YYYY年M月D日 形式に変換する
-function formatDate(dateStr: string): string {
-  const [year, month, day] = dateStr.split('-')
-  return `${year}年${parseInt(month)}月${parseInt(day)}日`
 }
 
 // exam_date が同日の bookmark が2件以上ある場合に警告表示

--- a/components/calendar/ConflictBanner.tsx
+++ b/components/calendar/ConflictBanner.tsx
@@ -6,6 +6,12 @@ interface ConflictBannerProps {
   bookmarks: Bookmark[]
 }
 
+// YYYY-MM-DD を YYYY年M月D日 形式に変換する
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-')
+  return `${year}年${parseInt(month)}月${parseInt(day)}日`
+}
+
 // exam_date が同日の bookmark が2件以上ある場合に警告表示
 export function ConflictBanner({ bookmarks }: ConflictBannerProps) {
   const dateCounts = bookmarks.reduce<Record<string, number>>((acc, b) => {
@@ -16,6 +22,7 @@ export function ConflictBanner({ bookmarks }: ConflictBannerProps) {
   const conflictDates = Object.entries(dateCounts)
     .filter(([, count]) => count > 1)
     .map(([date]) => date)
+    .sort()
 
   if (conflictDates.length === 0) return null
 
@@ -27,7 +34,7 @@ export function ConflictBanner({ bookmarks }: ConflictBannerProps) {
       <div>
         <h3 className="text-destructive font-bold text-base">試験日の重複が検出されました！</h3>
         <p className="text-text-main/80 text-sm mt-1">
-          {conflictDates.join('、')} に複数の試験が重複しています。スケジュールを再確認してください。
+          {conflictDates.map(formatDate).join('、')} に複数の試験が重複しています。スケジュールを再確認してください。
         </p>
       </div>
     </div>

--- a/components/calendar/EventNode.tsx
+++ b/components/calendar/EventNode.tsx
@@ -1,16 +1,11 @@
 import { FlatEvent, EVENT_CONFIG } from './types'
 import { differenceInCalendarDays, parseISO } from 'date-fns'
+import { formatDate } from './utils'
 
 interface EventNodeProps {
   event: FlatEvent
   dimmed: boolean       // 非選択校のとき true → opacity-30
   conflicted: boolean   // exam_date が重複しているとき true
-}
-
-// 日付を日本語形式で表示
-function formatDate(dateStr: string): string {
-  const [year, month, day] = dateStr.split('-')
-  return `${year}年${parseInt(month)}月${parseInt(day)}日`
 }
 
 // 日付からカウントダウン文字列を生成
@@ -39,8 +34,8 @@ export function EventNode({ event, dimmed, conflicted }: EventNodeProps) {
 
       {/* イベント内容 */}
       <div
-        className={`flex-1 bg-[#FFFCF8] border rounded-xl p-3 mb-2 ${
-          conflicted ? 'border-destructive/30' : 'border-[rgba(111,78,55,0.12)]'
+        className={`flex-1 bg-bg-card border rounded-xl p-3 mb-2 ${
+          conflicted ? 'border-destructive/30' : 'border-border-custom'
         }`}
       >
         <div className="flex items-center justify-between gap-2 flex-wrap">
@@ -51,12 +46,12 @@ export function EventNode({ event, dimmed, conflicted }: EventNodeProps) {
             >
               {config.label}
             </span>
-            <p className="text-[#3D2B1F] font-semibold text-sm mt-1">{event.university_name}</p>
-            <p className="text-[#8B7355] text-xs">{event.department}</p>
+            <p className="text-text-main font-semibold text-sm mt-1">{event.university_name}</p>
+            <p className="text-text-sub text-xs">{event.department}</p>
           </div>
           <div className="text-right shrink-0">
-            <p className="text-[#3D2B1F] font-bold text-sm">{formatDate(event.date)}</p>
-            <p className="text-[#A89279] text-xs mt-0.5">{getCountdown(event.date)}</p>
+            <p className="text-text-main font-bold text-sm">{formatDate(event.date)}</p>
+            <p className="text-text-muted text-xs mt-0.5">{getCountdown(event.date)}</p>
           </div>
         </div>
       </div>

--- a/components/calendar/EventNode.tsx
+++ b/components/calendar/EventNode.tsx
@@ -1,0 +1,65 @@
+import { FlatEvent, EVENT_CONFIG } from './types'
+import { differenceInCalendarDays, parseISO } from 'date-fns'
+
+interface EventNodeProps {
+  event: FlatEvent
+  dimmed: boolean       // 非選択校のとき true → opacity-30
+  conflicted: boolean   // exam_date が重複しているとき true
+}
+
+// 日付を日本語形式で表示
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-')
+  return `${year}年${parseInt(month)}月${parseInt(day)}日`
+}
+
+// 日付からカウントダウン文字列を生成
+function getCountdown(dateStr: string): string {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const target = parseISO(dateStr)
+  const diff = differenceInCalendarDays(target, today)
+  if (diff > 0) return `あと ${diff} 日`
+  if (diff === 0) return '今日'
+  return `${Math.abs(diff)} 日前`
+}
+
+export function EventNode({ event, dimmed, conflicted }: EventNodeProps) {
+  const config = EVENT_CONFIG[event.eventType]
+
+  return (
+    <div className={`flex items-start gap-3 transition-opacity duration-200 ${dimmed ? 'opacity-30' : 'opacity-100'}`}>
+      {/* タイムラインドット */}
+      <div className="flex flex-col items-center shrink-0 mt-1">
+        <div
+          className={`w-3 h-3 rounded-full border-2 border-white shadow-sm ${conflicted ? 'ring-2 ring-destructive' : ''}`}
+          style={{ backgroundColor: config.color }}
+        />
+      </div>
+
+      {/* イベント内容 */}
+      <div
+        className={`flex-1 bg-[#FFFCF8] border rounded-xl p-3 mb-2 ${
+          conflicted ? 'border-destructive/30' : 'border-[rgba(111,78,55,0.12)]'
+        }`}
+      >
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div>
+            <span
+              className="text-xs font-bold px-2 py-0.5 rounded-full"
+              style={{ backgroundColor: `${config.color}20`, color: config.color }}
+            >
+              {config.label}
+            </span>
+            <p className="text-[#3D2B1F] font-semibold text-sm mt-1">{event.university_name}</p>
+            <p className="text-[#8B7355] text-xs">{event.department}</p>
+          </div>
+          <div className="text-right shrink-0">
+            <p className="text-[#3D2B1F] font-bold text-sm">{formatDate(event.date)}</p>
+            <p className="text-[#A89279] text-xs mt-0.5">{getCountdown(event.date)}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/calendar/GanttView.tsx
+++ b/components/calendar/GanttView.tsx
@@ -1,0 +1,180 @@
+// components/calendar/GanttView.tsx
+import { Bookmark, EVENT_CONFIG } from './types'
+import { differenceInCalendarDays, parseISO, format, addDays } from 'date-fns'
+
+interface GanttViewProps {
+  bookmarks: Bookmark[]
+  selectedId: string | null
+}
+
+// 全ブックマークの最早日・最遅日を計算
+function getDateRange(bookmarks: Bookmark[]): { minDate: string; maxDate: string } {
+  const allDates: string[] = bookmarks.flatMap((b) =>
+    [
+      b.schedule.application_start,
+      b.schedule.application_end,
+      b.schedule.exam_date,
+      b.schedule.interview_date,
+      b.schedule.result_date,
+    ].filter((d): d is string => d !== null)
+  )
+  const sorted = [...allDates].sort()
+  return { minDate: sorted[0], maxDate: sorted[sorted.length - 1] }
+}
+
+// 月ごとのヘッダーを生成（「6月」「7月」など）
+function buildMonthHeaders(
+  minDate: string,
+  totalDays: number
+): { label: string; offsetDays: number; spanDays: number }[] {
+  const headers: { label: string; offsetDays: number; spanDays: number }[] = []
+  const start = parseISO(minDate)
+  let cursor = new Date(start.getFullYear(), start.getMonth(), 1)
+
+  while (differenceInCalendarDays(cursor, start) < totalDays) {
+    const offset = Math.max(0, differenceInCalendarDays(cursor, start))
+    const nextMonth = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1)
+    const endOfMonth = addDays(nextMonth, -1)
+    const span =
+      Math.min(differenceInCalendarDays(endOfMonth, start) + 1, totalDays) - offset
+    if (span > 0) {
+      headers.push({ label: format(cursor, 'M月'), offsetDays: offset, spanDays: span })
+    }
+    cursor = nextMonth
+  }
+  return headers
+}
+
+const POINT_EVENTS = ['exam_date', 'interview_date', 'result_date'] as const
+
+export function GanttView({ bookmarks, selectedId }: GanttViewProps) {
+  if (bookmarks.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-text-muted py-20">
+        <p>表示するデータがありません</p>
+      </div>
+    )
+  }
+
+  const { minDate, maxDate } = getDateRange(bookmarks)
+  const totalDays =
+    differenceInCalendarDays(parseISO(maxDate), parseISO(minDate)) + 7
+  const monthHeaders = buildMonthHeaders(minDate, totalDays)
+
+  function toPct(dateStr: string): number {
+    return (
+      (differenceInCalendarDays(parseISO(dateStr), parseISO(minDate)) / totalDays) *
+      100
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-x-auto">
+      <div style={{ minWidth: '600px' }}>
+        {/* 月ヘッダー */}
+        <div className="flex border-b border-border-custom pb-2 mb-4 ml-44">
+          {monthHeaders.map((h) => (
+            <div
+              key={h.label + h.offsetDays}
+              className="text-xs font-bold text-text-sub text-center"
+              style={{ width: `${(h.spanDays / totalDays) * 100}%` }}
+            >
+              {h.label}
+            </div>
+          ))}
+        </div>
+
+        {/* 凡例 */}
+        <div className="flex items-center gap-4 mb-6 flex-wrap ml-44">
+          <span className="text-xs font-bold text-text-sub">凡例:</span>
+          {(
+            Object.entries(EVENT_CONFIG) as [
+              keyof typeof EVENT_CONFIG,
+              { label: string; color: string },
+            ][]
+          ).map(([key, cfg]) => (
+            <div key={key} className="flex items-center gap-1.5">
+              <div
+                className={`${
+                  POINT_EVENTS.includes(key as (typeof POINT_EVENTS)[number])
+                    ? 'w-2.5 h-2.5 rounded-full'
+                    : 'w-6 h-2.5 rounded-sm'
+                }`}
+                style={{ backgroundColor: cfg.color }}
+              />
+              <span className="text-xs text-text-sub">{cfg.label}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* 各学校の行 */}
+        {bookmarks.map((b) => {
+          const isDimmed = selectedId !== null && b.id !== selectedId
+          const appStartPct = toPct(b.schedule.application_start)
+          const appEndPct = toPct(b.schedule.application_end)
+          const appWidthPct = appEndPct - appStartPct
+
+          return (
+            <div
+              key={b.id}
+              className={`flex items-center gap-2 mb-3 transition-opacity duration-200 ${
+                isDimmed ? 'opacity-30' : 'opacity-100'
+              }`}
+            >
+              {/* 学校名 */}
+              <div className="w-44 shrink-0 pr-3 text-right">
+                <p className="text-sm font-semibold text-text-main leading-tight truncate">
+                  {b.university_name}
+                </p>
+                <p className="text-[10px] text-text-sub truncate">{b.department}</p>
+              </div>
+
+              {/* ガントバー */}
+              <div className="flex-1 relative h-8">
+                {/* 出願期間バー */}
+                <div
+                  className="absolute top-1/2 -translate-y-1/2 h-3 rounded-sm opacity-80"
+                  style={{
+                    left: `${appStartPct}%`,
+                    width: `${appWidthPct}%`,
+                    backgroundColor: EVENT_CONFIG.application_start.color,
+                  }}
+                />
+
+                {/* ポイントイベント（試験日・面接日・合格発表） */}
+                {POINT_EVENTS.map((eventType) => {
+                  const dateStr = b.schedule[eventType]
+                  if (!dateStr) return null
+                  return (
+                    <div
+                      key={eventType}
+                      className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm"
+                      style={{
+                        left: `${toPct(dateStr)}%`,
+                        backgroundColor: EVENT_CONFIG[eventType].color,
+                      }}
+                      title={`${EVENT_CONFIG[eventType].label}: ${dateStr}`}
+                    />
+                  )
+                })}
+
+                {/* 今日ライン */}
+                {(() => {
+                  const todayStr = new Date().toISOString().slice(0, 10)
+                  const todayPct = toPct(todayStr)
+                  if (todayPct < 0 || todayPct > 100) return null
+                  return (
+                    <div
+                      className="absolute top-0 bottom-0 w-px bg-destructive/50"
+                      style={{ left: `${todayPct}%` }}
+                    />
+                  )
+                })()}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/calendar/SchoolSidebar.tsx
+++ b/components/calendar/SchoolSidebar.tsx
@@ -1,0 +1,69 @@
+import { Bookmark } from './types'
+import { Badge } from '@/components/ui/badge'
+
+interface SchoolSidebarProps {
+  bookmarks: Bookmark[]
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+}
+
+const STATUS_LABEL: Record<Bookmark['status'], string> = {
+  planning: '検討中',
+  applied: '出願済',
+  examined: '受験済',
+  passed: '合格',
+  failed: '不合格',
+}
+
+export function SchoolSidebar({ bookmarks, selectedId, onSelect }: SchoolSidebarProps) {
+  return (
+    <aside className="w-60 shrink-0 bg-[#FFFCF8] border border-[rgba(111,78,55,0.12)] rounded-2xl overflow-hidden self-start sticky top-6">
+      <div className="p-4 border-b border-[rgba(111,78,55,0.12)]">
+        <h2 className="text-[#3D2B1F] font-bold text-sm">大学名称</h2>
+      </div>
+
+      {/* 全て表示ボタン */}
+      <button
+        onClick={() => onSelect(null)}
+        className={`w-full text-left px-4 py-3 text-sm font-medium transition-colors border-b border-[rgba(111,78,55,0.12)] ${
+          selectedId === null
+            ? 'bg-[rgba(111,78,55,0.05)] text-[#6F4E37] border-l-2 border-l-[#6F4E37]'
+            : 'text-[#8B7355] hover:bg-[#FFFAF5] border-l-2 border-l-transparent'
+        }`}
+      >
+        すべて表示
+      </button>
+
+      {bookmarks.map((b) => {
+        const isSelected = selectedId === b.id
+        const typeColor =
+          b.type === '国立' || b.type === '公立'
+            ? 'bg-[rgba(86,130,115,0.12)] text-[#3D6B5A]'
+            : 'bg-[rgba(160,110,90,0.12)] text-[#8B5E3C]'
+
+        return (
+          <button
+            key={b.id}
+            onClick={() => onSelect(isSelected ? null : b.id)}
+            className={`w-full text-left px-4 py-3 transition-colors border-b border-[rgba(111,78,55,0.12)] last:border-b-0 ${
+              isSelected
+                ? 'bg-[rgba(111,78,55,0.05)] border-l-2 border-l-[#6F4E37]'
+                : 'hover:bg-[#FFFAF5] border-l-2 border-l-transparent'
+            }`}
+          >
+            <p className={`text-sm font-semibold leading-tight ${isSelected ? 'text-[#6F4E37]' : 'text-[#3D2B1F]'}`}>
+              {b.university_name}
+            </p>
+            <p className="text-[#8B7355] text-xs mt-0.5 truncate">{b.department}</p>
+            <div className="flex items-center gap-1.5 mt-1.5">
+              <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full ${typeColor}`}>
+                {b.type}
+              </span>
+              <span className="text-[10px] text-[#A89279]">{STATUS_LABEL[b.status]}</span>
+            </div>
+          </button>
+        )
+      })}
+    </aside>
+  )
+}

--- a/components/calendar/SchoolSidebar.tsx
+++ b/components/calendar/SchoolSidebar.tsx
@@ -1,5 +1,4 @@
 import { Bookmark } from './types'
-import { Badge } from '@/components/ui/badge'
 
 interface SchoolSidebarProps {
   bookmarks: Bookmark[]
@@ -17,7 +16,7 @@ const STATUS_LABEL: Record<Bookmark['status'], string> = {
 
 export function SchoolSidebar({ bookmarks, selectedId, onSelect }: SchoolSidebarProps) {
   return (
-    <aside className="w-60 shrink-0 bg-bg-card border border-border-custom rounded-2xl overflow-hidden self-start sticky top-6">
+    <aside className="w-full lg:w-60 shrink-0 bg-bg-card border border-border-custom rounded-2xl overflow-hidden self-start lg:sticky lg:top-6">
       <div className="p-4 border-b border-border-custom">
         <h2 className="text-text-main font-bold text-sm">大学名称</h2>
       </div>

--- a/components/calendar/SchoolSidebar.tsx
+++ b/components/calendar/SchoolSidebar.tsx
@@ -17,18 +17,18 @@ const STATUS_LABEL: Record<Bookmark['status'], string> = {
 
 export function SchoolSidebar({ bookmarks, selectedId, onSelect }: SchoolSidebarProps) {
   return (
-    <aside className="w-60 shrink-0 bg-[#FFFCF8] border border-[rgba(111,78,55,0.12)] rounded-2xl overflow-hidden self-start sticky top-6">
-      <div className="p-4 border-b border-[rgba(111,78,55,0.12)]">
-        <h2 className="text-[#3D2B1F] font-bold text-sm">大学名称</h2>
+    <aside className="w-60 shrink-0 bg-bg-card border border-border-custom rounded-2xl overflow-hidden self-start sticky top-6">
+      <div className="p-4 border-b border-border-custom">
+        <h2 className="text-text-main font-bold text-sm">大学名称</h2>
       </div>
 
       {/* 全て表示ボタン */}
       <button
         onClick={() => onSelect(null)}
-        className={`w-full text-left px-4 py-3 text-sm font-medium transition-colors border-b border-[rgba(111,78,55,0.12)] ${
+        className={`w-full text-left px-4 py-3 text-sm font-medium transition-colors border-b border-border-custom ${
           selectedId === null
-            ? 'bg-[rgba(111,78,55,0.05)] text-[#6F4E37] border-l-2 border-l-[#6F4E37]'
-            : 'text-[#8B7355] hover:bg-[#FFFAF5] border-l-2 border-l-transparent'
+            ? 'bg-primary/5 text-primary border-l-2 border-l-primary'
+            : 'text-text-sub hover:bg-bg-hover border-l-2 border-l-transparent'
         }`}
       >
         すべて表示
@@ -38,28 +38,28 @@ export function SchoolSidebar({ bookmarks, selectedId, onSelect }: SchoolSidebar
         const isSelected = selectedId === b.id
         const typeColor =
           b.type === '国立' || b.type === '公立'
-            ? 'bg-[rgba(86,130,115,0.12)] text-[#3D6B5A]'
-            : 'bg-[rgba(160,110,90,0.12)] text-[#8B5E3C]'
+            ? 'bg-badge-public text-badge-public-text'
+            : 'bg-badge-private text-badge-private-text'
 
         return (
           <button
             key={b.id}
             onClick={() => onSelect(isSelected ? null : b.id)}
-            className={`w-full text-left px-4 py-3 transition-colors border-b border-[rgba(111,78,55,0.12)] last:border-b-0 ${
+            className={`w-full text-left px-4 py-3 transition-colors border-b border-border-custom last:border-b-0 ${
               isSelected
-                ? 'bg-[rgba(111,78,55,0.05)] border-l-2 border-l-[#6F4E37]'
-                : 'hover:bg-[#FFFAF5] border-l-2 border-l-transparent'
+                ? 'bg-primary/5 border-l-2 border-l-primary'
+                : 'hover:bg-bg-hover border-l-2 border-l-transparent'
             }`}
           >
-            <p className={`text-sm font-semibold leading-tight ${isSelected ? 'text-[#6F4E37]' : 'text-[#3D2B1F]'}`}>
+            <p className={`text-sm font-semibold leading-tight ${isSelected ? 'text-primary' : 'text-text-main'}`}>
               {b.university_name}
             </p>
-            <p className="text-[#8B7355] text-xs mt-0.5 truncate">{b.department}</p>
+            <p className="text-text-sub text-xs mt-0.5 truncate">{b.department}</p>
             <div className="flex items-center gap-1.5 mt-1.5">
               <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full ${typeColor}`}>
                 {b.type}
               </span>
-              <span className="text-[10px] text-[#A89279]">{STATUS_LABEL[b.status]}</span>
+              <span className="text-[10px] text-text-muted">{STATUS_LABEL[b.status]}</span>
             </div>
           </button>
         )

--- a/components/calendar/TimelineView.tsx
+++ b/components/calendar/TimelineView.tsx
@@ -1,0 +1,116 @@
+import { Bookmark, FlatEvent, EventType } from './types'
+import { EventNode } from './EventNode'
+
+interface TimelineViewProps {
+  bookmarks: Bookmark[]
+  selectedId: string | null
+}
+
+// Bookmark の schedule から FlatEvent[] を生成
+function flattenEvents(bookmarks: Bookmark[]): FlatEvent[] {
+  const eventTypes: EventType[] = [
+    'application_start',
+    'application_end',
+    'exam_date',
+    'interview_date',
+    'result_date',
+  ]
+
+  const events: FlatEvent[] = []
+  for (const b of bookmarks) {
+    for (const eventType of eventTypes) {
+      const date = b.schedule[eventType]
+      if (!date) continue
+      events.push({
+        bookmarkId: b.id,
+        university_name: b.university_name,
+        department: b.department,
+        type: b.type,
+        eventType,
+        date,
+      })
+    }
+  }
+  // 日付昇順でソート
+  return events.sort((a, b) => a.date.localeCompare(b.date))
+}
+
+// イベントリストを月ごとにグループ化
+function groupByMonth(events: FlatEvent[]): Map<string, FlatEvent[]> {
+  const map = new Map<string, FlatEvent[]>()
+  for (const event of events) {
+    const month = event.date.slice(0, 7)  // "YYYY-MM"
+    if (!map.has(month)) map.set(month, [])
+    map.get(month)!.push(event)
+  }
+  return map
+}
+
+// exam_date が重複している bookmarkId のセット
+function getConflictedIds(bookmarks: Bookmark[]): Set<string> {
+  const dateCounts: Record<string, string[]> = {}
+  for (const b of bookmarks) {
+    const d = b.schedule.exam_date
+    if (!dateCounts[d]) dateCounts[d] = []
+    dateCounts[d].push(b.id)
+  }
+  const conflicted = new Set<string>()
+  for (const ids of Object.values(dateCounts)) {
+    if (ids.length > 1) ids.forEach((id) => conflicted.add(id))
+  }
+  return conflicted
+}
+
+// "YYYY-MM" → "YYYY年M月" に変換
+function formatMonth(ym: string): string {
+  const [year, month] = ym.split('-')
+  return `${year}年${parseInt(month)}月`
+}
+
+export function TimelineView({ bookmarks, selectedId }: TimelineViewProps) {
+  const events = flattenEvents(bookmarks)
+  const grouped = groupByMonth(events)
+  const conflictedIds = getConflictedIds(bookmarks)
+
+  if (events.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-text-muted py-20">
+        <p>表示するイベントがありません</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      {Array.from(grouped.entries()).map(([month, monthEvents]) => (
+        <div key={month} className="mb-8">
+          {/* 月セパレーター */}
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-sm font-bold text-text-sub bg-primary/5 rounded-full px-3 py-1">
+              {formatMonth(month)}
+            </span>
+            <div className="flex-1 h-px bg-border-custom" />
+          </div>
+
+          {/* タイムラインライン + イベントノード */}
+          <div className="relative pl-4 border-l-2 border-border-custom ml-4 space-y-1">
+            {monthEvents.map((event, idx) => {
+              const isConflicted =
+                event.eventType === 'exam_date' && conflictedIds.has(event.bookmarkId)
+              const isDimmed = selectedId !== null && event.bookmarkId !== selectedId
+
+              return (
+                <EventNode
+                  key={`${event.bookmarkId}-${event.eventType}-${idx}`}
+                  event={event}
+                  dimmed={isDimmed}
+                  conflicted={isConflicted}
+                />
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/calendar/mockData.ts
+++ b/components/calendar/mockData.ts
@@ -1,0 +1,65 @@
+// components/calendar/mockData.ts
+import { Bookmark } from './types'
+
+export const MOCK_BOOKMARKS: Bookmark[] = [
+  {
+    id: 'b1',
+    university_name: '早稲田大学',
+    university_name_zh: '早稻田大学',
+    department: '経営学研究科 (Waseda Business)',
+    type: '私立',
+    status: 'planning',
+    schedule: {
+      application_start: '2026-06-01',
+      application_end: '2026-06-15',
+      exam_date: '2026-07-21',
+      interview_date: '2026-07-21',
+      result_date: '2026-08-10',
+    },
+  },
+  {
+    id: 'b2',
+    university_name: '慶應義塾大学',
+    university_name_zh: '庆应义塾大学',
+    department: '商学研究科 (Keio Commerce)',
+    type: '私立',
+    status: 'applied',
+    schedule: {
+      application_start: '2026-06-10',
+      application_end: '2026-06-20',
+      exam_date: '2026-07-10',
+      interview_date: null,
+      result_date: '2026-08-05',
+    },
+  },
+  {
+    id: 'b3',
+    university_name: '一橋大学',
+    university_name_zh: '一桥大学',
+    department: '経営管理研究科 (Hitotsubashi Mngmt)',
+    type: '国立',
+    status: 'planning',
+    schedule: {
+      application_start: '2026-07-01',
+      application_end: '2026-08-15',
+      exam_date: '2026-09-10',
+      interview_date: '2026-09-20',
+      result_date: '2026-10-05',
+    },
+  },
+  {
+    id: 'b4',
+    university_name: '東京大学',
+    university_name_zh: '东京大学',
+    department: '工学系研究科',
+    type: '国立',
+    status: 'planning',
+    schedule: {
+      application_start: '2026-06-20',
+      application_end: '2026-07-10',
+      exam_date: '2026-07-21',  // 早稲田と同日 → conflict!
+      interview_date: null,
+      result_date: '2026-09-01',
+    },
+  },
+]

--- a/components/calendar/types.ts
+++ b/components/calendar/types.ts
@@ -36,7 +36,7 @@ export interface FlatEvent {
 // イベント種別ごとの表示設定
 export const EVENT_CONFIG: Record<EventType, { label: string; color: string }> = {
   application_start: { label: '出願開始', color: '#C4956A' },
-  application_end:   { label: '出願締切', color: '#E8463A' },
+  application_end:   { label: '出願締切', color: '#AF4448' },
   exam_date:         { label: '試験日',   color: '#6F4E37' },
   interview_date:    { label: '面接日',   color: '#3D6B5A' },
   result_date:       { label: '合格発表', color: '#8B5E3C' },

--- a/components/calendar/types.ts
+++ b/components/calendar/types.ts
@@ -1,0 +1,43 @@
+// components/calendar/types.ts
+
+export type UniversityType = '国立' | '公立' | '私立'
+export type BookmarkStatus = 'planning' | 'applied' | 'examined' | 'passed' | 'failed'
+export type EventType = 'application_start' | 'application_end' | 'exam_date' | 'interview_date' | 'result_date'
+export type ViewType = 'timeline' | 'gantt'
+
+export interface Schedule {
+  application_start: string   // "YYYY-MM-DD"
+  application_end: string
+  exam_date: string
+  interview_date: string | null
+  result_date: string
+}
+
+export interface Bookmark {
+  id: string
+  university_name: string       // 日本語名
+  university_name_zh: string    // 中国語名
+  department: string
+  type: UniversityType
+  status: BookmarkStatus
+  schedule: Schedule
+}
+
+// タイムライン上の平坦化されたイベント
+export interface FlatEvent {
+  bookmarkId: string
+  university_name: string
+  department: string
+  type: UniversityType
+  eventType: EventType
+  date: string   // "YYYY-MM-DD"
+}
+
+// イベント種別ごとの表示設定
+export const EVENT_CONFIG: Record<EventType, { label: string; color: string }> = {
+  application_start: { label: '出願開始', color: '#C4956A' },
+  application_end:   { label: '出願締切', color: '#E8463A' },
+  exam_date:         { label: '試験日',   color: '#6F4E37' },
+  interview_date:    { label: '面接日',   color: '#3D6B5A' },
+  result_date:       { label: '合格発表', color: '#8B5E3C' },
+}

--- a/components/calendar/utils.ts
+++ b/components/calendar/utils.ts
@@ -1,0 +1,5 @@
+// YYYY-MM-DD を YYYY年M月D日 形式に変換する
+export function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-')
+  return `${year}年${parseInt(month)}月${parseInt(day)}日`
+}


### PR DESCRIPTION
## 概要

`/calendar` ページをカードリスト形式から、**左サイドバー + タイムライン/ガントビュー切替**の2ペインレイアウトにリデザインしました。

## 変更内容

### 新規ファイル

| ファイル | 役割 |
|---------|------|
| `components/calendar/types.ts` | `Bookmark` 型・`EVENT_CONFIG` |
| `components/calendar/mockData.ts` | モックデータ（4校、意図的な重複あり） |
| `components/calendar/utils.ts` | `formatDate` 共有ユーティリティ |
| `components/calendar/ConflictBanner.tsx` | 試験日重複警告バナー |
| `components/calendar/EventNode.tsx` | タイムラインイベントノード（カウントダウン付き） |
| `components/calendar/SchoolSidebar.tsx` | クリッカブルな学校リストサイドバー |
| `components/calendar/TimelineView.tsx` | 縦型タイムライン（月別グループ） |
| `components/calendar/GanttView.tsx` | 横型ガントチャート（出願バー＋イベントドット） |

### 変更ファイル

- `app/calendar/page.tsx` — 全面リライト（`useState` で状態管理）

## 主な機能

- **Timeline / Gantt ビュー切替**ボタン
- **学校サイドバー**でクリックすると他校がフェードアウト（`opacity-30`）
- **試験日重複検出**：早稲田・東京大が同日のため自動でバナー表示
- **日付表示**：`2026年7月21日` 形式（日本語）
- **カウントダウン**：「あと N 日 / 今日 / N 日前」
- **モバイル対応**：`lg` ブレークポイントで縦積み→2ペイン

## 今後の対応

- Supabase実データへの切り替え → #3
- `interview_date` カラムのマイグレーション → #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar page displaying entrance exam schedules with timeline and gantt chart view options
  * School filter sidebar for managing and selecting specific exam schedules
  * Automatic conflict detection and warnings for overlapping exam dates
  * Empty state with call-to-action for adding schools to the calendar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->