### PR TITLE
feat: 3種類（Sepia, Light, Dark）のテーマモードと切り替え機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .superpowers/
+.worktrees/

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -43,7 +43,7 @@ export default function CalendarPage() {
                 }`}
               >
                 <LayoutList className="w-4 h-4" />
-                Timeline
+                一覧
               </button>
               <button
                 onClick={() => setActiveView('gantt')}
@@ -54,7 +54,7 @@ export default function CalendarPage() {
                 }`}
               >
                 <GanttChartSquare className="w-4 h-4" />
-                Gantt
+                年表
               </button>
             </div>
 

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,20 +1,64 @@
 // app/calendar/page.tsx
 'use client'
 
-import { useState } from 'react'
-import Link from 'next/link'
-import { CalendarIcon, LayoutList, GanttChartSquare } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { CalendarIcon, LayoutList, GanttChartSquare, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { SchoolSidebar } from '@/components/calendar/SchoolSidebar'
 import { TimelineView } from '@/components/calendar/TimelineView'
 import { GanttView } from '@/components/calendar/GanttView'
 import { ConflictBanner } from '@/components/calendar/ConflictBanner'
-import { MOCK_BOOKMARKS } from '@/components/calendar/mockData'
-import type { ViewType } from '@/components/calendar/types'
+import { AddScheduleModal } from '@/components/calendar/AddScheduleModal'
+import { toBookmark } from '@/components/calendar/types'
+import type { Bookmark, ViewType, UserScheduleRow } from '@/components/calendar/types'
+import { createBrowserClient } from '@/lib/supabase/browser'
 
 export default function CalendarPage() {
+  const router = useRouter()
   const [activeView, setActiveView] = useState<ViewType>('timeline')
   const [selectedSchoolId, setSelectedSchoolId] = useState<string | null>(null)
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAddModal, setShowAddModal] = useState(false)
+
+  const fetchBookmarks = async () => {
+    const supabase = createBrowserClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    if (!user) {
+      router.push('/auth/login')
+      return
+    }
+
+    const { data } = await supabase
+      .from('user_schedules')
+      .select('*')
+      .order('created_at', { ascending: false })
+
+    setBookmarks((data as UserScheduleRow[] ?? []).map(toBookmark))
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchBookmarks()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleDelete = async (id: string) => {
+    const supabase = createBrowserClient()
+    await supabase.from('user_schedules').delete().eq('id', id)
+    setBookmarks((prev) => prev.filter((b) => b.id !== id))
+    if (selectedSchoolId === id) setSelectedSchoolId(null)
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-bg-main flex items-center justify-center">
+        <p className="text-text-sub">読み込み中...</p>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-bg-main py-10 px-6">
@@ -32,7 +76,6 @@ export default function CalendarPage() {
           </div>
 
           <div className="flex items-center gap-3">
-            {/* ビュー切替ボタン */}
             <div className="flex items-center bg-bg-card border border-border-custom rounded-xl p-1 gap-1">
               <button
                 onClick={() => setActiveView('timeline')}
@@ -58,53 +101,60 @@ export default function CalendarPage() {
               </button>
             </div>
 
-            <Link href="/dashboard">
-              <Button className="bg-primary text-white rounded-xl font-bold px-5 h-10 shadow-md hover:opacity-90 transition-all">
-                学校を追加する
-              </Button>
-            </Link>
+            <Button
+              onClick={() => setShowAddModal(true)}
+              className="bg-primary text-white rounded-xl font-bold px-5 h-10 shadow-md hover:opacity-90 transition-all flex items-center gap-2"
+            >
+              <Plus className="w-4 h-4" />
+              学校を追加
+            </Button>
           </div>
         </header>
 
         {/* 重複警告バナー */}
-        <ConflictBanner bookmarks={MOCK_BOOKMARKS} />
+        <ConflictBanner bookmarks={bookmarks} />
 
-        {/* メインコンテンツ: サイドバー + ビューエリア */}
-        {MOCK_BOOKMARKS.length === 0 ? (
+        {/* メインコンテンツ */}
+        {bookmarks.length === 0 ? (
           <div className="text-center py-32 bg-bg-card rounded-3xl border border-dashed border-border-custom">
             <CalendarIcon className="w-16 h-16 text-text-muted mx-auto mb-6" />
             <h3 className="text-xl font-serif text-text-main">カレンダーは空です</h3>
             <p className="text-text-sub mt-2 mb-8">志望校を追加してスケジュールを管理しましょう。</p>
-            <Link href="/dashboard">
-              <Button className="bg-primary text-white rounded-xl font-bold px-8 h-12 shadow-lg">
-                学校を探す
-              </Button>
-            </Link>
+            <Button
+              onClick={() => setShowAddModal(true)}
+              className="bg-primary text-white rounded-xl font-bold px-8 h-12 shadow-lg"
+            >
+              学校を追加する
+            </Button>
           </div>
         ) : (
           <div className="flex flex-col lg:flex-row gap-6 items-start">
             <SchoolSidebar
-              bookmarks={MOCK_BOOKMARKS}
+              bookmarks={bookmarks}
               selectedId={selectedSchoolId}
               onSelect={setSelectedSchoolId}
+              onDelete={handleDelete}
             />
-
             <div className="flex-1 bg-bg-card border border-border-custom rounded-2xl p-6 min-h-[600px] flex flex-col">
               {activeView === 'timeline' ? (
-                <TimelineView
-                  bookmarks={MOCK_BOOKMARKS}
-                  selectedId={selectedSchoolId}
-                />
+                <TimelineView bookmarks={bookmarks} selectedId={selectedSchoolId} />
               ) : (
-                <GanttView
-                  bookmarks={MOCK_BOOKMARKS}
-                  selectedId={selectedSchoolId}
-                />
+                <GanttView bookmarks={bookmarks} selectedId={selectedSchoolId} />
               )}
             </div>
           </div>
         )}
       </div>
+
+      {showAddModal && (
+        <AddScheduleModal
+          onClose={() => setShowAddModal(false)}
+          onAdded={() => {
+            setShowAddModal(false)
+            fetchBookmarks()
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { SchoolCard } from "@/components/SchoolCard";
 import { SearchFilters } from "@/components/SearchFilters";
-import { supabase } from "@/lib/supabase";
+import { createServerClient } from "@/lib/supabase/server";
 import { School } from "lucide-react";
 import { Suspense } from "react";
 
@@ -13,10 +13,13 @@ export default async function DashboardPage(props: {
   const query = ((searchParams.q as string) || "").trim();
   const type = (searchParams.type as string) || "all";
 
+  const supabase = await createServerClient();
+
   // universitiesとuniversity_schedulesを結合して取得
   let dbQuery = supabase
     .from("universities")
-    .select(`
+    .select(
+      `
       id,
       name_ja,
       name_zh,
@@ -32,21 +35,20 @@ export default async function DashboardPage(props: {
         tags,
         year
       )
-    `)
+    `,
+    )
     .order("name_ja");
 
   // カテゴリフィルタ
   if (type === "public") {
-    dbQuery = dbQuery.in("type", ["国立", "公立"]);
+    dbQuery = dbQuery.in("type", ["国立", "公立", "国公立"]);
   } else if (type === "private") {
     dbQuery = dbQuery.eq("type", "私立");
   }
 
   // テキスト検索（学校名 or 中国語名）
   if (query) {
-    dbQuery = dbQuery.or(
-      `name_ja.ilike.%${query}%,name_zh.ilike.%${query}%`
-    );
+    dbQuery = dbQuery.or(`name_ja.ilike.%${query}%,name_zh.ilike.%${query}%`);
   }
 
   const { data: universities, error } = await dbQuery;
@@ -74,7 +76,7 @@ export default async function DashboardPage(props: {
   }));
 
   return (
-    <div className="min-h-screen bg-bg-main">
+    <div className="min-h-screen bg-bg-main pt-20 md:pt-24">
       {/* Header Section */}
       <header className="pt-16 pb-24 px-6 max-w-7xl mx-auto text-center">
         <div className="inline-flex items-center gap-2 bg-primary/5 text-primary rounded-full px-4 py-2 text-sm font-bold mb-6">

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,27 +4,72 @@
 
 @custom-variant dark (&:is(.dark *));
 
-:root {
-  --background: #FFF8F0;
-  --foreground: #3D2B1F;
-  --card: #FFFCF8;
-  --card-foreground: #3D2B1F;
-  --popover: #FFFCF8;
-  --popover-foreground: #3D2B1F;
-  --primary: #6F4E37;
-  --primary-foreground: #FFF8F0;
-  --secondary: #F3E5D8;
-  --secondary-foreground: #6F4E37;
-  --muted: #F9F4EF;
-  --muted-foreground: #8B7355;
-  --accent: #C4956A;
-  --accent-foreground: #FFF8F0;
-  --destructive: #AF4448;
-  --destructive-foreground: #FFF8F0;
+:root,
+[data-theme="sepia"] {
+  --background: #fff8f0;
+  --foreground: #3d2b1f;
+  --card: #fffcf8;
+  --card-foreground: #3d2b1f;
+  --popover: #fffcf8;
+  --popover-foreground: #3d2b1f;
+  --primary: #6f4e37;
+  --primary-foreground: #fff8f0;
+  --secondary: #f3e5d8;
+  --secondary-foreground: #6f4e37;
+  --muted: #f9f4ef;
+  --muted-foreground: #8b7355;
+  --accent: #c4956a;
+  --accent-foreground: #fff8f0;
+  --destructive: #af4448;
+  --destructive-foreground: #fff8f0;
   --border: rgba(111, 78, 55, 0.12);
   --input: rgba(111, 78, 55, 0.15);
-  --ring: #C4956A;
+  --ring: #c4956a;
   --radius: 1rem;
+}
+
+[data-theme="light"] {
+  --background: #ffffff;
+  --foreground: #1a1a1a;
+  --card: #ffffff;
+  --card-foreground: #1a1a1a;
+  --popover: #ffffff;
+  --popover-foreground: #1a1a1a;
+  --primary: #6f4e37; /* 统一使用品牌褐色 */
+  --primary-foreground: #ffffff;
+  --secondary: #f5f5f5;
+  --secondary-foreground: #6f4e37;
+  --muted: #f8f8f8;
+  --muted-foreground: #737373;
+  --accent: #8b7355;
+  --accent-foreground: #ffffff;
+  --destructive: #af4448;
+  --destructive-foreground: #ffffff;
+  --border: #e5e5e5;
+  --input: #e5e5e5;
+  --ring: #6f4e37;
+}
+
+[data-theme="dark"] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --card: #141414;
+  --card-foreground: #ededed;
+  --popover: #141414;
+  --popover-foreground: #ededed;
+  --primary: #a89279; /* 黑色背景下使用较浅的褐色以保证对比度 */
+  --primary-foreground: #0a0a0a;
+  --secondary: #262626;
+  --secondary-foreground: #a89279;
+  --muted: #1a1a1a;
+  --muted-foreground: #a3a3a3;
+  --accent: #c4956a;
+  --accent-foreground: #0a0a0a;
+  --destructive: #f87171;
+  --destructive-foreground: #ffffff;
+  --border: #262626;
+  --input: #262626;
+  --ring: #a89279;
 }
 
 @theme {
@@ -48,62 +93,28 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
 
-  --color-accent-custom: #C4956A;
-  --color-accent-light: #D4A574;
-  --color-accent-pale: #E8C9A0;
-  --color-bg-main: #FFF8F0;
-  --color-bg-card: #FFFCF8;
-  --color-bg-hover: #FFFAF5;
-  --color-text-main: #3D2B1F;
-  --color-text-sub: #8B7355;
-  --color-text-muted: #A89279;
-  --color-border-custom: rgba(111, 78, 55, 0.12);
-  --color-border-hover: #D4A574;
+  --color-accent-custom: var(--accent);
+  --color-bg-main: var(--background);
+  --color-bg-card: var(--card);
+  --color-bg-hover: var(--muted);
+  --color-text-main: var(--foreground);
+  --color-text-sub: var(--muted-foreground);
+  --color-text-muted: var(--muted-foreground);
+  --color-border-custom: var(--border);
+  --color-border-hover: var(--accent);
+
   --color-badge-public: rgba(86, 130, 115, 0.12);
-  --color-badge-public-text: #3D6B5A;
+  --color-badge-public-text: #3d6b5a;
   --color-badge-private: rgba(160, 110, 90, 0.12);
-  --color-badge-private-text: #8B5E3C;
+  --color-badge-private-text: #8b5e3c;
 
   --font-serif: var(--font-playfair);
-  --font-sans: var(--font-dm-sans), var(--font-noto-sans), system-ui, sans-serif;
+  --font-sans:
+    var(--font-dm-sans), var(--font-noto-sans), system-ui, sans-serif;
 
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Playfair_Display, DM_Sans, Noto_Sans_JP, Geist } from "next/font/google
 import "./globals.css";
 import { cn } from "@/lib/utils";
 import { Navbar } from "@/components/Navbar";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geist = Geist({subsets:['latin'],variable:'--font-sans'});
 
@@ -35,10 +36,18 @@ export default function RootLayout({
     <html
       lang="ja"
       className={cn("h-full", "antialiased", playfair.variable, dmSans.variable, notoTranslate.variable, "font-sans", geist.variable)}
+      suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col font-sans relative">
-        <Navbar />
-        {children}
+      <body className="min-h-full flex flex-col font-sans relative bg-background text-foreground transition-colors duration-300">
+        <ThemeProvider
+          attribute="data-theme"
+          defaultTheme="sepia"
+          enableSystem={false}
+          storageKey="go-in-theme"
+        >
+          <Navbar />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -41,6 +41,13 @@ export function Navbar() {
   return (
     <nav className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-white/80 backdrop-blur-lg border border-border-custom rounded-full px-4 py-2 flex items-center gap-2 shadow-2xl z-50 md:top-6 md:bottom-auto md:h-14">
       <div className="flex items-center gap-1">
+        {user && (
+          <div className="hidden md:flex items-center gap-2 px-4 py-2 text-sm font-bold text-primary border-r border-border-custom mr-2">
+            <span className="truncate max-w-[150px]">
+              {user.user_metadata?.full_name || user.email?.split("@")[0]} 様
+            </span>
+          </div>
+        )}
         {navItems.map((item) => {
           const isActive = pathname === item.href;
           const Icon = item.icon;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,20 +1,41 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { School, Calendar, User } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { School, Calendar, User, LogOut } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { createBrowserClient } from "@/lib/supabase/browser";
+import { useEffect, useState } from "react";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
 
 export function Navbar() {
   const pathname = usePathname();
+  const router = useRouter();
+  const [user, setUser] = useState<SupabaseUser | null>(null);
 
-  // Hide navbar on auth pages
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getUser().then(({ data }) => setUser(data.user));
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => listener.subscription.unsubscribe();
+  }, []);
+
+  const handleLogout = async () => {
+    const supabase = createBrowserClient();
+    await supabase.auth.signOut();
+    setUser(null);
+    router.push("/dashboard");
+    router.refresh();
+  };
+
   if (pathname.startsWith("/auth")) return null;
 
   const navItems = [
     { name: "Dashboard", href: "/dashboard", icon: School },
     { name: "マイカレンダー", href: "/calendar", icon: Calendar },
-    { name: "ログイン", href: "/auth/login", icon: User },
   ];
 
   return (
@@ -23,23 +44,46 @@ export function Navbar() {
         {navItems.map((item) => {
           const isActive = pathname === item.href;
           const Icon = item.icon;
-          
           return (
             <Link
               key={item.href}
               href={item.href}
               className={cn(
                 "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all",
-                isActive 
-                  ? "bg-primary text-white shadow-md" 
+                isActive
+                  ? "bg-primary text-white shadow-md"
                   : "text-text-sub hover:bg-primary/5 hover:text-primary"
               )}
             >
               <Icon className="w-4 h-4" />
-              <span className={cn("hidden md:inline")}>{item.name}</span>
+              <span className="hidden md:inline">{item.name}</span>
             </Link>
           );
         })}
+
+        {user ? (
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold text-text-sub hover:bg-primary/5 hover:text-primary transition-all"
+            title={user.email}
+          >
+            <LogOut className="w-4 h-4" />
+            <span className="hidden md:inline">ログアウト</span>
+          </button>
+        ) : (
+          <Link
+            href="/auth/login"
+            className={cn(
+              "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all",
+              pathname === "/auth/login"
+                ? "bg-primary text-white shadow-md"
+                : "text-text-sub hover:bg-primary/5 hover:text-primary"
+            )}
+          >
+            <User className="w-4 h-4" />
+            <span className="hidden md:inline">ログイン</span>
+          </Link>
+        )}
       </div>
     </nav>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -13,7 +13,7 @@ export function Navbar() {
 
   const navItems = [
     { name: "Dashboard", href: "/dashboard", icon: School },
-    { name: "カレンダー", href: "/calendar", icon: Calendar },
+    { name: "マイカレンダー", href: "/calendar", icon: Calendar },
     { name: "ログイン", href: "/auth/login", icon: User },
   ];
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,24 +2,41 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { School, Calendar, User, LogOut } from "lucide-react";
+import { School, Calendar, User, LogOut, Palette, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { createBrowserClient } from "@/lib/supabase/browser";
 import { useEffect, useState } from "react";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
+import { useTheme } from "next-themes";
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 export function Navbar() {
   const pathname = usePathname();
   const router = useRouter();
   const [user, setUser] = useState<SupabaseUser | null>(null);
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   useEffect(() => {
     const supabase = createBrowserClient();
     supabase.auth.getUser().then(({ data }) => setUser(data.user));
 
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
-    });
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setUser(session?.user ?? null);
+      },
+    );
     return () => listener.subscription.unsubscribe();
   }, []);
 
@@ -38,8 +55,14 @@ export function Navbar() {
     { name: "マイカレンダー", href: "/calendar", icon: Calendar },
   ];
 
+  const themes = [
+    { name: "Sepia", value: "sepia", color: "#6F4E37" },
+    { name: "Light", value: "light", color: "#FFFFFF" },
+    { name: "Dark", value: "dark", color: "#141414" },
+  ];
+
   return (
-    <nav className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-white/80 backdrop-blur-lg border border-border-custom rounded-full px-4 py-2 flex items-center gap-2 shadow-2xl z-50 md:top-6 md:bottom-auto md:h-14">
+    <nav className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-card/80 backdrop-blur-lg border border-border-custom rounded-full px-4 py-2 flex items-center gap-2 shadow-2xl z-50 md:top-6 md:bottom-auto md:h-14">
       <div className="flex items-center gap-1">
         {user && (
           <div className="hidden md:flex items-center gap-2 px-4 py-2 text-sm font-bold text-primary border-r border-border-custom mr-2">
@@ -59,7 +82,7 @@ export function Navbar() {
                 "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all",
                 isActive
                   ? "bg-primary text-white shadow-md"
-                  : "text-text-sub hover:bg-primary/5 hover:text-primary"
+                  : "text-text-sub hover:bg-primary/5 hover:text-primary",
               )}
             >
               <Icon className="w-4 h-4" />
@@ -84,13 +107,57 @@ export function Navbar() {
               "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all",
               pathname === "/auth/login"
                 ? "bg-primary text-white shadow-md"
-                : "text-text-sub hover:bg-primary/5 hover:text-primary"
+                : "text-text-sub hover:bg-primary/5 hover:text-primary",
             )}
           >
             <User className="w-4 h-4" />
             <span className="hidden md:inline">ログイン</span>
           </Link>
         )}
+
+        {/* Theme Toggle Button */}
+        <div className="pl-2 ml-1 border-l border-border-custom">
+          <DropdownMenu>
+            <MenuPrimitive.Trigger
+              className="flex items-center justify-center w-10 h-10 rounded-full text-text-sub hover:bg-primary/5 hover:text-primary transition-all relative group cursor-pointer outline-none"
+              aria-label="テーマ切り替え"
+            >
+              <Palette className="w-5 h-5 transition-transform group-hover:scale-110" />
+              <div className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-primary" />
+            </MenuPrimitive.Trigger>
+            <DropdownMenuContent
+              align="end"
+              className="w-40 bg-card/95 backdrop-blur-md border-border-custom rounded-2xl shadow-2xl p-2"
+            >
+              <div className="px-2 py-1.5 text-xs font-bold text-text-muted uppercase tracking-wider">
+                テーマ
+              </div>
+              {themes.map((t) => (
+                <DropdownMenuItem
+                  key={t.value}
+                  onClick={() => setTheme(t.value)}
+                  className={cn(
+                    "flex items-center justify-between px-3 py-2.5 rounded-xl cursor-pointer transition-colors mb-1 last:mb-0",
+                    mounted && theme === t.value
+                      ? "bg-primary text-white font-bold"
+                      : "text-text-main hover:bg-primary/10",
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className="w-3 h-3 rounded-full border border-black/10 dark:border-white/20"
+                      style={{ backgroundColor: t.color }}
+                    />
+                    <span className="text-sm">{t.name}</span>
+                  </div>
+                  {mounted && theme === t.value && (
+                    <Check className="w-4 h-4" />
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
     </nav>
   );

--- a/components/SchoolCard.tsx
+++ b/components/SchoolCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Calendar, GraduationCap, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { createBrowserClient } from "@/lib/supabase/browser";
 
 interface Schedule {
   id: string;
@@ -31,13 +32,26 @@ interface SchoolCardProps {
 export function SchoolCard({ university }: SchoolCardProps) {
   const router = useRouter();
   const typeColorClass =
-    university.type === "国立" || university.type === "公立"
+    university.type === "国立" ||
+    university.type === "公立" ||
+    university.type === "国公立"
       ? "bg-badge-public text-badge-public-text"
       : "bg-badge-private text-badge-private-text";
 
-  const handleAddToCalendar = () => {
-    // In a real scenario, check if logged in. If not, redirect to login.
-    router.push("/auth/login");
+  const handleAddToCalendar = async () => {
+    const supabase = createBrowserClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      router.push("/auth/login");
+      return;
+    }
+
+    // TODO: 実際のカレンダー追加ロジックをここに実装
+    console.log("Adding to calendar for user:", user.id);
+    router.push("/calendar");
   };
 
   return (
@@ -49,7 +63,9 @@ export function SchoolCard({ university }: SchoolCardProps) {
           <Badge
             className={`${typeColorClass} rounded-xl border-none font-medium`}
           >
-            {university.type}
+            {university.type === "国立" || university.type === "公立"
+              ? "国公立"
+              : university.type}
           </Badge>
           <Button
             variant="ghost"

--- a/components/SearchFilters.tsx
+++ b/components/SearchFilters.tsx
@@ -30,7 +30,10 @@ export function SearchFilters() {
       params.delete("q");
     }
     router.push(`?${params.toString()}`, { scroll: false });
-  }, [debouncedSearch, router, searchParams]);
+    // searchParamsを依存配列に含めると、router.pushによるURL更新が再度useEffectを
+    // トリガーして無限ループになるため、debouncedSearchの変化のみに反応させる
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
 
   const handleFilter = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -5,9 +5,17 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Mail, Lock, Loader2, ArrowLeft } from "lucide-react";
 import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase/browser";
 
 interface AuthFormProps {
   mode: "login" | "signup";
@@ -18,29 +26,49 @@ export function AuthForm({ mode }: AuthFormProps) {
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    
-    // In a real scenario, integrate Supabase Auth here
-    // const { error } = await supabase.auth.signInWithPassword({ email, password })
-    
-    setTimeout(() => {
-      setLoading(false);
-      router.push("/dashboard");
-    }, 1000);
+    setErrorMsg(null);
+
+    const supabase = createBrowserClient();
+
+    if (mode === "login") {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) {
+        setErrorMsg("メールアドレスまたはパスワードが正しくありません。");
+        setLoading(false);
+        return;
+      }
+    } else {
+      const { error } = await supabase.auth.signUp({ email, password });
+      if (error) {
+        if (error.message.includes("already registered")) {
+          setErrorMsg("このメールアドレスはすでに登録されています。");
+        } else {
+          setErrorMsg("登録に失敗しました。もう一度お試しください。");
+        }
+        setLoading(false);
+        return;
+      }
+    }
+
+    router.push("/calendar");
+    router.refresh();
   };
 
   const title = mode === "login" ? "ログイン" : "新規登録";
-  const description = mode === "login" 
-    ? "アカウントにログインして、志望校を管理しましょう。" 
-    : "アカウントを作成して、受験スケジュールを計画しましょう。";
+  const description =
+    mode === "login"
+      ? "アカウントにログインして、志望校を管理しましょう。"
+      : "アカウントを作成して、受験スケジュールを計画しましょう。";
 
   return (
     <div className="min-h-screen bg-bg-main flex flex-col items-center justify-center px-6">
-      <Link 
-        href="/dashboard" 
+      <Link
+        href="/dashboard"
         className="mb-8 flex items-center gap-2 text-text-sub hover:text-primary transition-colors font-bold"
       >
         <ArrowLeft className="w-4 h-4" />
@@ -49,7 +77,7 @@ export function AuthForm({ mode }: AuthFormProps) {
 
       <Card className="w-full max-w-md bg-bg-card border-border-custom rounded-2xl shadow-xl overflow-hidden">
         <div className="h-2 bg-gradient-to-r from-primary to-accent" />
-        
+
         <CardHeader className="pt-10 pb-6 text-center">
           <CardTitle className="text-3xl font-serif text-text-main">{title}</CardTitle>
           <CardDescription className="text-text-sub mt-2">{description}</CardDescription>
@@ -57,14 +85,22 @@ export function AuthForm({ mode }: AuthFormProps) {
 
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-6 px-8">
+            {errorMsg && (
+              <p className="text-sm text-destructive bg-destructive/10 rounded-xl px-4 py-3">
+                {errorMsg}
+              </p>
+            )}
+
             <div className="space-y-2">
-              <Label htmlFor="email" className="text-text-main font-bold">メールアドレス</Label>
+              <Label htmlFor="email" className="text-text-main font-bold">
+                メールアドレス
+              </Label>
               <div className="relative">
                 <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
-                <Input 
-                  id="email" 
-                  type="email" 
-                  placeholder="name@example.com" 
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="name@example.com"
                   className="pl-10 border-primary/15 rounded-xl focus:border-accent focus:ring-4 focus:ring-accent/10 h-12"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -74,25 +110,28 @@ export function AuthForm({ mode }: AuthFormProps) {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-text-main font-bold">パスワード</Label>
+              <Label htmlFor="password" className="text-text-main font-bold">
+                パスワード
+              </Label>
               <div className="relative">
                 <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
-                <Input 
-                  id="password" 
-                  type="password" 
-                  placeholder="••••••••" 
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="••••••••"
                   className="pl-10 border-primary/15 rounded-xl focus:border-accent focus:ring-4 focus:ring-accent/10 h-12"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
+                  minLength={6}
                 />
               </div>
             </div>
           </CardContent>
 
           <CardFooter className="flex flex-col gap-6 pt-6 pb-10 px-8">
-            <Button 
-              type="submit" 
+            <Button
+              type="submit"
               className="w-full bg-primary text-white rounded-xl h-12 font-bold hover:opacity-90 shadow-lg"
               disabled={loading}
             >

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -13,7 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Mail, Lock, Loader2, ArrowLeft } from "lucide-react";
+import { Mail, Lock, Loader2, ArrowLeft, User } from "lucide-react";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase/browser";
 
@@ -26,6 +26,8 @@ export function AuthForm({ mode }: AuthFormProps) {
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [fullName, setFullName] = useState("");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -36,14 +38,31 @@ export function AuthForm({ mode }: AuthFormProps) {
     const supabase = createBrowserClient();
 
     if (mode === "login") {
-      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
       if (error) {
         setErrorMsg("メールアドレスまたはパスワードが正しくありません。");
         setLoading(false);
         return;
       }
     } else {
-      const { error } = await supabase.auth.signUp({ email, password });
+      if (password !== confirmPassword) {
+        setErrorMsg("パスワードが一致しません。");
+        setLoading(false);
+        return;
+      }
+
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: {
+            full_name: fullName,
+          },
+        },
+      });
       if (error) {
         if (error.message.includes("already registered")) {
           setErrorMsg("このメールアドレスはすでに登録されています。");
@@ -79,8 +98,12 @@ export function AuthForm({ mode }: AuthFormProps) {
         <div className="h-2 bg-gradient-to-r from-primary to-accent" />
 
         <CardHeader className="pt-10 pb-6 text-center">
-          <CardTitle className="text-3xl font-serif text-text-main">{title}</CardTitle>
-          <CardDescription className="text-text-sub mt-2">{description}</CardDescription>
+          <CardTitle className="text-3xl font-serif text-text-main">
+            {title}
+          </CardTitle>
+          <CardDescription className="text-text-sub mt-2">
+            {description}
+          </CardDescription>
         </CardHeader>
 
         <form onSubmit={handleSubmit}>
@@ -89,6 +112,26 @@ export function AuthForm({ mode }: AuthFormProps) {
               <p className="text-sm text-destructive bg-destructive/10 rounded-xl px-4 py-3">
                 {errorMsg}
               </p>
+            )}
+
+            {mode === "signup" && (
+              <div className="space-y-2">
+                <Label htmlFor="fullName" className="text-text-main font-bold">
+                  お名前
+                </Label>
+                <div className="relative">
+                  <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                  <Input
+                    id="fullName"
+                    type="text"
+                    placeholder="山田 太郎"
+                    className="pl-10 border-primary/15 rounded-xl focus:border-accent focus:ring-4 focus:ring-accent/10 h-12"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                    required
+                  />
+                </div>
+              </div>
             )}
 
             <div className="space-y-2">
@@ -127,6 +170,30 @@ export function AuthForm({ mode }: AuthFormProps) {
                 />
               </div>
             </div>
+
+            {mode === "signup" && (
+              <div className="space-y-2">
+                <Label
+                  htmlFor="confirmPassword"
+                  className="text-text-main font-bold"
+                >
+                  パスワード（確認）
+                </Label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                  <Input
+                    id="confirmPassword"
+                    type="password"
+                    placeholder="••••••••"
+                    className="pl-10 border-primary/15 rounded-xl focus:border-accent focus:ring-4 focus:ring-accent/10 h-12"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                    minLength={6}
+                  />
+                </div>
+              </div>
+            )}
           </CardContent>
 
           <CardFooter className="flex flex-col gap-6 pt-6 pb-10 px-8">
@@ -142,14 +209,20 @@ export function AuthForm({ mode }: AuthFormProps) {
               {mode === "login" ? (
                 <>
                   アカウントをお持ちでないですか？{" "}
-                  <Link href="/auth/signup" className="text-primary font-bold hover:underline">
+                  <Link
+                    href="/auth/signup"
+                    className="text-primary font-bold hover:underline"
+                  >
                     新規登録
                   </Link>
                 </>
               ) : (
                 <>
                   既にアカウントをお持ちですか？{" "}
-                  <Link href="/auth/login" className="text-primary font-bold hover:underline">
+                  <Link
+                    href="/auth/login"
+                    className="text-primary font-bold hover:underline"
+                  >
                     ログイン
                   </Link>
                 </>

--- a/components/calendar/AddScheduleModal.tsx
+++ b/components/calendar/AddScheduleModal.tsx
@@ -1,0 +1,377 @@
+// components/calendar/AddScheduleModal.tsx
+'use client'
+
+import { useState } from 'react'
+import { X, Search, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { createBrowserClient } from '@/lib/supabase/browser'
+
+interface AddScheduleModalProps {
+  onClose: () => void
+  onAdded: () => void
+}
+
+type Tab = 'search' | 'manual'
+
+interface UniversityResult {
+  id: string
+  name_ja: string
+  name_zh: string
+  type: string
+  departments: string[]
+}
+
+interface ScheduleResult {
+  id: string
+  department: string
+  application_start: string | null
+  application_end: string | null
+  exam_date: string | null
+  interview_date: string | null
+  result_date: string | null
+}
+
+export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
+  const [tab, setTab] = useState<Tab>('search')
+
+  // 検索タブ用のstate
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<UniversityResult[]>([])
+  const [selectedUniversity, setSelectedUniversity] = useState<UniversityResult | null>(null)
+  const [schedules, setSchedules] = useState<ScheduleResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const [adding, setAdding] = useState(false)
+
+  // 手動入力タブ用のstate
+  const [manual, setManual] = useState({
+    university_name: '',
+    university_name_zh: '',
+    university_type: '私立',
+    department: '',
+    application_start: '',
+    application_end: '',
+    exam_date: '',
+    interview_date: '',
+    result_date: '',
+  })
+
+  const handleSearch = async (query: string) => {
+    setSearchQuery(query)
+    if (query.length < 1) {
+      setSearchResults([])
+      return
+    }
+    setSearching(true)
+    const supabase = createBrowserClient()
+    const { data } = await supabase
+      .from('universities')
+      .select('id, name_ja, name_zh, type, departments')
+      .or(`name_ja.ilike.%${query}%,name_zh.ilike.%${query}%`)
+      .limit(8)
+    setSearchResults(
+      (data ?? []).map((u) => ({
+        ...u,
+        departments: Array.isArray(u.departments) ? u.departments : [],
+      }))
+    )
+    setSearching(false)
+  }
+
+  const handleSelectUniversity = async (uni: UniversityResult) => {
+    setSelectedUniversity(uni)
+    setSearchResults([])
+    setSearchQuery(uni.name_ja)
+    const supabase = createBrowserClient()
+    const { data } = await supabase
+      .from('university_schedules')
+      .select('id, department, application_start, application_end, exam_date, interview_date, result_date')
+      .eq('university_id', uni.id)
+    setSchedules(data ?? [])
+  }
+
+  const handleAddFromSearch = async (schedule: ScheduleResult) => {
+    if (!selectedUniversity) return
+    setAdding(true)
+    const supabase = createBrowserClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return
+
+    await supabase.from('user_schedules').insert({
+      user_id: user.id,
+      university_schedule_id: schedule.id,
+      university_name: selectedUniversity.name_ja,
+      university_name_zh: selectedUniversity.name_zh,
+      university_type: selectedUniversity.type,
+      department: schedule.department,
+      application_start: schedule.application_start,
+      application_end: schedule.application_end,
+      exam_date: schedule.exam_date,
+      interview_date: schedule.interview_date,
+      result_date: schedule.result_date,
+    })
+    setAdding(false)
+    onAdded()
+  }
+
+  const handleAddManual = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!manual.university_name) return
+    setAdding(true)
+    const supabase = createBrowserClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return
+
+    await supabase.from('user_schedules').insert({
+      user_id: user.id,
+      university_name: manual.university_name,
+      university_name_zh: manual.university_name_zh || null,
+      university_type: manual.university_type,
+      department: manual.department || null,
+      application_start: manual.application_start || null,
+      application_end: manual.application_end || null,
+      exam_date: manual.exam_date || null,
+      interview_date: manual.interview_date || null,
+      result_date: manual.result_date || null,
+    })
+    setAdding(false)
+    onAdded()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* オーバーレイ */}
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" onClick={onClose} />
+
+      {/* モーダル本体 */}
+      <div className="relative bg-bg-card border border-border-custom rounded-2xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between p-6 border-b border-border-custom">
+          <h2 className="text-xl font-serif text-text-main">学校を追加</h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-xl text-text-muted hover:bg-primary/5 hover:text-primary transition-all"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* タブ切替 */}
+        <div className="flex border-b border-border-custom">
+          <button
+            onClick={() => setTab('search')}
+            className={`flex-1 py-3 text-sm font-bold transition-all ${
+              tab === 'search'
+                ? 'text-primary border-b-2 border-primary'
+                : 'text-text-sub hover:text-text-main'
+            }`}
+          >
+            データベースから検索
+          </button>
+          <button
+            onClick={() => setTab('manual')}
+            className={`flex-1 py-3 text-sm font-bold transition-all ${
+              tab === 'manual'
+                ? 'text-primary border-b-2 border-primary'
+                : 'text-text-sub hover:text-text-main'
+            }`}
+          >
+            手動で入力
+          </button>
+        </div>
+
+        <div className="p-6">
+          {/* 検索タブ */}
+          {tab === 'search' && (
+            <div className="space-y-4">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                <Input
+                  placeholder="大学名を入力..."
+                  className="pl-10 border-primary/15 rounded-xl h-11"
+                  value={searchQuery}
+                  onChange={(e) => handleSearch(e.target.value)}
+                />
+                {searching && (
+                  <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted animate-spin" />
+                )}
+              </div>
+
+              {/* 検索候補 */}
+              {searchResults.length > 0 && (
+                <div className="border border-border-custom rounded-xl overflow-hidden">
+                  {searchResults.map((uni) => (
+                    <button
+                      key={uni.id}
+                      onClick={() => handleSelectUniversity(uni)}
+                      className="w-full text-left px-4 py-3 hover:bg-bg-hover transition-colors border-b border-border-custom last:border-b-0"
+                    >
+                      <p className="text-sm font-semibold text-text-main">{uni.name_ja}</p>
+                      <p className="text-xs text-text-sub">{uni.name_zh} · {uni.type}</p>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* 選択された大学の日程一覧 */}
+              {selectedUniversity && schedules.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-sm font-bold text-text-main">
+                    {selectedUniversity.name_ja} の日程
+                  </p>
+                  {schedules.map((s) => (
+                    <div
+                      key={s.id}
+                      className="bg-primary/5 border border-primary/10 rounded-xl p-3 space-y-1"
+                    >
+                      <p className="text-sm font-bold text-text-main">{s.department}</p>
+                      {s.exam_date && (
+                        <p className="text-xs text-text-sub">試験日: {s.exam_date}</p>
+                      )}
+                      {s.application_end && (
+                        <p className="text-xs text-text-sub">出願締切: {s.application_end}</p>
+                      )}
+                      <Button
+                        onClick={() => handleAddFromSearch(s)}
+                        disabled={adding}
+                        className="mt-2 w-full bg-primary text-white rounded-xl h-9 text-sm font-bold hover:opacity-90"
+                      >
+                        {adding ? <Loader2 className="w-4 h-4 animate-spin" /> : '追加する'}
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {selectedUniversity && schedules.length === 0 && (
+                <p className="text-sm text-text-muted text-center py-4">
+                  この大学の日程データはまだ登録されていません。<br />
+                  「手動で入力」タブから追加してください。
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* 手動入力タブ */}
+          {tab === 'manual' && (
+            <form onSubmit={handleAddManual} className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">
+                  学校名 <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  placeholder="例：東京大学"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.university_name}
+                  onChange={(e) => setManual({ ...manual, university_name: e.target.value })}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">学校名（中国語）</Label>
+                <Input
+                  placeholder="例：东京大学"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.university_name_zh}
+                  onChange={(e) => setManual({ ...manual, university_name_zh: e.target.value })}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">種別</Label>
+                <div className="flex gap-2">
+                  {(['国立', '公立', '私立'] as const).map((t) => (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => setManual({ ...manual, university_type: t })}
+                      className={`flex-1 py-2 rounded-xl text-sm font-bold transition-all ${
+                        manual.university_type === t
+                          ? 'bg-primary text-white'
+                          : 'bg-primary/5 text-primary hover:bg-primary/10'
+                      }`}
+                    >
+                      {t}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">研究科</Label>
+                <Input
+                  placeholder="例：工学系研究科"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.department}
+                  onChange={(e) => setManual({ ...manual, department: e.target.value })}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">出願開始日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.application_start}
+                    onChange={(e) => setManual({ ...manual, application_start: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">出願締切日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.application_end}
+                    onChange={(e) => setManual({ ...manual, application_end: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">試験日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.exam_date}
+                    onChange={(e) => setManual({ ...manual, exam_date: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">面接日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.interview_date}
+                    onChange={(e) => setManual({ ...manual, interview_date: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">合格発表日</Label>
+                <Input
+                  type="date"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.result_date}
+                  onChange={(e) => setManual({ ...manual, result_date: e.target.value })}
+                />
+              </div>
+
+              <Button
+                type="submit"
+                disabled={adding || !manual.university_name}
+                className="w-full bg-primary text-white rounded-xl h-12 font-bold hover:opacity-90 shadow-md mt-2"
+              >
+                {adding ? <Loader2 className="w-5 h-5 animate-spin" /> : '追加する'}
+              </Button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/calendar/AddScheduleModal.tsx
+++ b/components/calendar/AddScheduleModal.tsx
@@ -1,104 +1,109 @@
 // components/calendar/AddScheduleModal.tsx
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { X, Search, Loader2 } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { createBrowserClient } from '@/lib/supabase/browser'
+import { useState } from "react";
+import { X, Search, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { createBrowserClient } from "@/lib/supabase/browser";
 
 interface AddScheduleModalProps {
-  onClose: () => void
-  onAdded: () => void
+  onClose: () => void;
+  onAdded: () => void;
 }
 
-type Tab = 'search' | 'manual'
+type Tab = "search" | "manual";
 
 interface UniversityResult {
-  id: string
-  name_ja: string
-  name_zh: string
-  type: string
-  departments: string[]
+  id: string;
+  name_ja: string;
+  name_zh: string;
+  type: string;
+  departments: string[];
 }
 
 interface ScheduleResult {
-  id: string
-  department: string
-  application_start: string | null
-  application_end: string | null
-  exam_date: string | null
-  interview_date: string | null
-  result_date: string | null
+  id: string;
+  department: string;
+  application_start: string | null;
+  application_end: string | null;
+  exam_date: string | null;
+  interview_date: string | null;
+  result_date: string | null;
 }
 
 export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
-  const [tab, setTab] = useState<Tab>('search')
+  const [tab, setTab] = useState<Tab>("search");
 
   // 検索タブ用のstate
-  const [searchQuery, setSearchQuery] = useState('')
-  const [searchResults, setSearchResults] = useState<UniversityResult[]>([])
-  const [selectedUniversity, setSelectedUniversity] = useState<UniversityResult | null>(null)
-  const [schedules, setSchedules] = useState<ScheduleResult[]>([])
-  const [searching, setSearching] = useState(false)
-  const [adding, setAdding] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<UniversityResult[]>([]);
+  const [selectedUniversity, setSelectedUniversity] =
+    useState<UniversityResult | null>(null);
+  const [schedules, setSchedules] = useState<ScheduleResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [adding, setAdding] = useState(false);
 
   // 手動入力タブ用のstate
   const [manual, setManual] = useState({
-    university_name: '',
-    university_name_zh: '',
-    university_type: '私立',
-    department: '',
-    application_start: '',
-    application_end: '',
-    exam_date: '',
-    interview_date: '',
-    result_date: '',
-  })
+    university_name: "",
+    university_name_zh: "",
+    university_type: "私立",
+    department: "",
+    application_start: "",
+    application_end: "",
+    exam_date: "",
+    interview_date: "",
+    result_date: "",
+  });
 
   const handleSearch = async (query: string) => {
-    setSearchQuery(query)
+    setSearchQuery(query);
     if (query.length < 1) {
-      setSearchResults([])
-      return
+      setSearchResults([]);
+      return;
     }
-    setSearching(true)
-    const supabase = createBrowserClient()
+    setSearching(true);
+    const supabase = createBrowserClient();
     const { data } = await supabase
-      .from('universities')
-      .select('id, name_ja, name_zh, type, departments')
+      .from("universities")
+      .select("id, name_ja, name_zh, type, departments")
       .or(`name_ja.ilike.%${query}%,name_zh.ilike.%${query}%`)
-      .limit(8)
+      .limit(8);
     setSearchResults(
       (data ?? []).map((u) => ({
         ...u,
         departments: Array.isArray(u.departments) ? u.departments : [],
-      }))
-    )
-    setSearching(false)
-  }
+      })),
+    );
+    setSearching(false);
+  };
 
   const handleSelectUniversity = async (uni: UniversityResult) => {
-    setSelectedUniversity(uni)
-    setSearchResults([])
-    setSearchQuery(uni.name_ja)
-    const supabase = createBrowserClient()
+    setSelectedUniversity(uni);
+    setSearchResults([]);
+    setSearchQuery(uni.name_ja);
+    const supabase = createBrowserClient();
     const { data } = await supabase
-      .from('university_schedules')
-      .select('id, department, application_start, application_end, exam_date, interview_date, result_date')
-      .eq('university_id', uni.id)
-    setSchedules(data ?? [])
-  }
+      .from("university_schedules")
+      .select(
+        "id, department, application_start, application_end, exam_date, interview_date, result_date",
+      )
+      .eq("university_id", uni.id);
+    setSchedules(data ?? []);
+  };
 
   const handleAddFromSearch = async (schedule: ScheduleResult) => {
-    if (!selectedUniversity) return
-    setAdding(true)
-    const supabase = createBrowserClient()
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user) return
+    if (!selectedUniversity) return;
+    setAdding(true);
+    const supabase = createBrowserClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
 
-    await supabase.from('user_schedules').insert({
+    await supabase.from("user_schedules").insert({
       user_id: user.id,
       university_schedule_id: schedule.id,
       university_name: selectedUniversity.name_ja,
@@ -110,20 +115,22 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
       exam_date: schedule.exam_date,
       interview_date: schedule.interview_date,
       result_date: schedule.result_date,
-    })
-    setAdding(false)
-    onAdded()
-  }
+    });
+    setAdding(false);
+    onAdded();
+  };
 
   const handleAddManual = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!manual.university_name) return
-    setAdding(true)
-    const supabase = createBrowserClient()
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user) return
+    e.preventDefault();
+    if (!manual.university_name) return;
+    setAdding(true);
+    const supabase = createBrowserClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
 
-    await supabase.from('user_schedules').insert({
+    await supabase.from("user_schedules").insert({
       user_id: user.id,
       university_name: manual.university_name,
       university_name_zh: manual.university_name_zh || null,
@@ -134,15 +141,18 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
       exam_date: manual.exam_date || null,
       interview_date: manual.interview_date || null,
       result_date: manual.result_date || null,
-    })
-    setAdding(false)
-    onAdded()
-  }
+    });
+    setAdding(false);
+    onAdded();
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* オーバーレイ */}
-      <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" onClick={onClose} />
+      <div
+        className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+        onClick={onClose}
+      />
 
       {/* モーダル本体 */}
       <div className="relative bg-bg-card border border-border-custom rounded-2xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
@@ -160,21 +170,21 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
         {/* タブ切替 */}
         <div className="flex border-b border-border-custom">
           <button
-            onClick={() => setTab('search')}
+            onClick={() => setTab("search")}
             className={`flex-1 py-3 text-sm font-bold transition-all ${
-              tab === 'search'
-                ? 'text-primary border-b-2 border-primary'
-                : 'text-text-sub hover:text-text-main'
+              tab === "search"
+                ? "text-primary border-b-2 border-primary"
+                : "text-text-sub hover:text-text-main"
             }`}
           >
             データベースから検索
           </button>
           <button
-            onClick={() => setTab('manual')}
+            onClick={() => setTab("manual")}
             className={`flex-1 py-3 text-sm font-bold transition-all ${
-              tab === 'manual'
-                ? 'text-primary border-b-2 border-primary'
-                : 'text-text-sub hover:text-text-main'
+              tab === "manual"
+                ? "text-primary border-b-2 border-primary"
+                : "text-text-sub hover:text-text-main"
             }`}
           >
             手動で入力
@@ -183,7 +193,7 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
 
         <div className="p-6">
           {/* 検索タブ */}
-          {tab === 'search' && (
+          {tab === "search" && (
             <div className="space-y-4">
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
@@ -207,8 +217,15 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
                       onClick={() => handleSelectUniversity(uni)}
                       className="w-full text-left px-4 py-3 hover:bg-bg-hover transition-colors border-b border-border-custom last:border-b-0"
                     >
-                      <p className="text-sm font-semibold text-text-main">{uni.name_ja}</p>
-                      <p className="text-xs text-text-sub">{uni.name_zh} · {uni.type}</p>
+                      <p className="text-sm font-semibold text-text-main">
+                        {uni.name_ja}
+                      </p>
+                      <p className="text-xs text-text-sub">
+                        {uni.name_zh} ·{" "}
+                        {uni.type === "国立" || uni.type === "公立"
+                          ? "国公立"
+                          : uni.type}
+                      </p>
                     </button>
                   ))}
                 </div>
@@ -225,19 +242,29 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
                       key={s.id}
                       className="bg-primary/5 border border-primary/10 rounded-xl p-3 space-y-1"
                     >
-                      <p className="text-sm font-bold text-text-main">{s.department}</p>
+                      <p className="text-sm font-bold text-text-main">
+                        {s.department}
+                      </p>
                       {s.exam_date && (
-                        <p className="text-xs text-text-sub">試験日: {s.exam_date}</p>
+                        <p className="text-xs text-text-sub">
+                          試験日: {s.exam_date}
+                        </p>
                       )}
                       {s.application_end && (
-                        <p className="text-xs text-text-sub">出願締切: {s.application_end}</p>
+                        <p className="text-xs text-text-sub">
+                          出願締切: {s.application_end}
+                        </p>
                       )}
                       <Button
                         onClick={() => handleAddFromSearch(s)}
                         disabled={adding}
                         className="mt-2 w-full bg-primary text-white rounded-xl h-9 text-sm font-bold hover:opacity-90"
                       >
-                        {adding ? <Loader2 className="w-4 h-4 animate-spin" /> : '追加する'}
+                        {adding ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          "追加する"
+                        )}
                       </Button>
                     </div>
                   ))}
@@ -246,7 +273,8 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
 
               {selectedUniversity && schedules.length === 0 && (
                 <p className="text-sm text-text-muted text-center py-4">
-                  この大学の日程データはまだ登録されていません。<br />
+                  この大学の日程データはまだ登録されていません。
+                  <br />
                   「手動で入力」タブから追加してください。
                 </p>
               )}
@@ -254,7 +282,7 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
           )}
 
           {/* 手動入力タブ */}
-          {tab === 'manual' && (
+          {tab === "manual" && (
             <form onSubmit={handleAddManual} className="space-y-4">
               <div className="space-y-2">
                 <Label className="text-text-main font-bold text-sm">
@@ -264,33 +292,41 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
                   placeholder="例：東京大学"
                   className="border-primary/15 rounded-xl h-11"
                   value={manual.university_name}
-                  onChange={(e) => setManual({ ...manual, university_name: e.target.value })}
+                  onChange={(e) =>
+                    setManual({ ...manual, university_name: e.target.value })
+                  }
                   required
                 />
               </div>
 
               <div className="space-y-2">
-                <Label className="text-text-main font-bold text-sm">学校名（中国語）</Label>
+                <Label className="text-text-main font-bold text-sm">
+                  学校名（中国語）
+                </Label>
                 <Input
                   placeholder="例：东京大学"
                   className="border-primary/15 rounded-xl h-11"
                   value={manual.university_name_zh}
-                  onChange={(e) => setManual({ ...manual, university_name_zh: e.target.value })}
+                  onChange={(e) =>
+                    setManual({ ...manual, university_name_zh: e.target.value })
+                  }
                 />
               </div>
 
               <div className="space-y-2">
                 <Label className="text-text-main font-bold text-sm">種別</Label>
                 <div className="flex gap-2">
-                  {(['国立', '公立', '私立'] as const).map((t) => (
+                  {(["国公立", "私立"] as const).map((t) => (
                     <button
                       key={t}
                       type="button"
-                      onClick={() => setManual({ ...manual, university_type: t })}
+                      onClick={() =>
+                        setManual({ ...manual, university_type: t })
+                      }
                       className={`flex-1 py-2 rounded-xl text-sm font-bold transition-all ${
                         manual.university_type === t
-                          ? 'bg-primary text-white'
-                          : 'bg-primary/5 text-primary hover:bg-primary/10'
+                          ? "bg-primary text-white"
+                          : "bg-primary/5 text-primary hover:bg-primary/10"
                       }`}
                     >
                       {t}
@@ -300,64 +336,91 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
               </div>
 
               <div className="space-y-2">
-                <Label className="text-text-main font-bold text-sm">研究科</Label>
+                <Label className="text-text-main font-bold text-sm">
+                  研究科
+                </Label>
                 <Input
                   placeholder="例：工学系研究科"
                   className="border-primary/15 rounded-xl h-11"
                   value={manual.department}
-                  onChange={(e) => setManual({ ...manual, department: e.target.value })}
+                  onChange={(e) =>
+                    setManual({ ...manual, department: e.target.value })
+                  }
                 />
               </div>
 
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-2">
-                  <Label className="text-text-main font-bold text-sm">出願開始日</Label>
+                  <Label className="text-text-main font-bold text-sm">
+                    出願開始日
+                  </Label>
                   <Input
                     type="date"
                     className="border-primary/15 rounded-xl h-11"
                     value={manual.application_start}
-                    onChange={(e) => setManual({ ...manual, application_start: e.target.value })}
+                    onChange={(e) =>
+                      setManual({
+                        ...manual,
+                        application_start: e.target.value,
+                      })
+                    }
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-text-main font-bold text-sm">出願締切日</Label>
+                  <Label className="text-text-main font-bold text-sm">
+                    出願締切日
+                  </Label>
                   <Input
                     type="date"
                     className="border-primary/15 rounded-xl h-11"
                     value={manual.application_end}
-                    onChange={(e) => setManual({ ...manual, application_end: e.target.value })}
+                    onChange={(e) =>
+                      setManual({ ...manual, application_end: e.target.value })
+                    }
                   />
                 </div>
               </div>
 
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-2">
-                  <Label className="text-text-main font-bold text-sm">試験日</Label>
+                  <Label className="text-text-main font-bold text-sm">
+                    試験日
+                  </Label>
                   <Input
                     type="date"
                     className="border-primary/15 rounded-xl h-11"
                     value={manual.exam_date}
-                    onChange={(e) => setManual({ ...manual, exam_date: e.target.value })}
+                    onChange={(e) =>
+                      setManual({ ...manual, exam_date: e.target.value })
+                    }
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-text-main font-bold text-sm">面接日</Label>
+                  <Label className="text-text-main font-bold text-sm">
+                    面接日
+                  </Label>
                   <Input
                     type="date"
                     className="border-primary/15 rounded-xl h-11"
                     value={manual.interview_date}
-                    onChange={(e) => setManual({ ...manual, interview_date: e.target.value })}
+                    onChange={(e) =>
+                      setManual({ ...manual, interview_date: e.target.value })
+                    }
                   />
                 </div>
               </div>
 
               <div className="space-y-2">
-                <Label className="text-text-main font-bold text-sm">合格発表日</Label>
+                <Label className="text-text-main font-bold text-sm">
+                  合格発表日
+                </Label>
                 <Input
                   type="date"
                   className="border-primary/15 rounded-xl h-11"
                   value={manual.result_date}
-                  onChange={(e) => setManual({ ...manual, result_date: e.target.value })}
+                  onChange={(e) =>
+                    setManual({ ...manual, result_date: e.target.value })
+                  }
                 />
               </div>
 
@@ -366,12 +429,16 @@ export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
                 disabled={adding || !manual.university_name}
                 className="w-full bg-primary text-white rounded-xl h-12 font-bold hover:opacity-90 shadow-md mt-2"
               >
-                {adding ? <Loader2 className="w-5 h-5 animate-spin" /> : '追加する'}
+                {adding ? (
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                ) : (
+                  "追加する"
+                )}
               </Button>
             </form>
           )}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/components/calendar/GanttView.tsx
+++ b/components/calendar/GanttView.tsx
@@ -1,10 +1,27 @@
 // components/calendar/GanttView.tsx
 import { Bookmark, EVENT_CONFIG } from './types'
 import { differenceInCalendarDays, parseISO, format, addDays } from 'date-fns'
+import { AlertTriangle } from 'lucide-react'
 
 interface GanttViewProps {
   bookmarks: Bookmark[]
   selectedId: string | null
+}
+
+// exam_dateが重複しているbookmarkIdのセット
+function getConflictedIds(bookmarks: Bookmark[]): Set<string> {
+  const dateCounts: Record<string, string[]> = {}
+  for (const b of bookmarks) {
+    const d = b.schedule.exam_date
+    if (!d) continue
+    if (!dateCounts[d]) dateCounts[d] = []
+    dateCounts[d].push(b.id)
+  }
+  const conflicted = new Set<string>()
+  for (const ids of Object.values(dateCounts)) {
+    if (ids.length > 1) ids.forEach((id) => conflicted.add(id))
+  }
+  return conflicted
 }
 
 // 全ブックマークの最早日・最遅日を計算
@@ -60,6 +77,7 @@ export function GanttView({ bookmarks, selectedId }: GanttViewProps) {
   const totalDays =
     differenceInCalendarDays(parseISO(maxDate), parseISO(minDate)) + 7
   const monthHeaders = buildMonthHeaders(minDate, totalDays)
+  const conflictedIds = getConflictedIds(bookmarks)
 
   function toPct(dateStr: string): number {
     return (
@@ -110,6 +128,7 @@ export function GanttView({ bookmarks, selectedId }: GanttViewProps) {
         {/* 各学校の行 */}
         {bookmarks.map((b) => {
           const isDimmed = selectedId !== null && b.id !== selectedId
+          const isConflicted = conflictedIds.has(b.id)
           const appStartPct = toPct(b.schedule.application_start)
           const appEndPct = toPct(b.schedule.application_end)
           const appWidthPct = appEndPct - appStartPct
@@ -123,9 +142,14 @@ export function GanttView({ bookmarks, selectedId }: GanttViewProps) {
             >
               {/* 学校名 */}
               <div className="w-44 shrink-0 pr-3 text-right">
-                <p className="text-sm font-semibold text-text-main leading-tight truncate">
-                  {b.university_name}
-                </p>
+                <div className="flex items-center justify-end gap-1">
+                  {isConflicted && (
+                    <AlertTriangle className="w-3.5 h-3.5 text-destructive shrink-0" />
+                  )}
+                  <p className="text-sm font-semibold text-text-main leading-tight truncate">
+                    {b.university_name}
+                  </p>
+                </div>
                 <p className="text-[10px] text-text-sub truncate">{b.department}</p>
               </div>
 
@@ -145,15 +169,20 @@ export function GanttView({ bookmarks, selectedId }: GanttViewProps) {
                 {POINT_EVENTS.map((eventType) => {
                   const dateStr = b.schedule[eventType]
                   if (!dateStr) return null
+                  const isDotConflicted = eventType === 'exam_date' && isConflicted
                   return (
                     <div
                       key={eventType}
-                      className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm"
+                      className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm ${
+                        isDotConflicted ? 'ring-2 ring-destructive ring-offset-1' : ''
+                      }`}
                       style={{
                         left: `${toPct(dateStr)}%`,
-                        backgroundColor: EVENT_CONFIG[eventType].color,
+                        backgroundColor: isDotConflicted
+                          ? '#AF4448'
+                          : EVENT_CONFIG[eventType].color,
                       }}
-                      title={`${EVENT_CONFIG[eventType].label}: ${dateStr}`}
+                      title={`${EVENT_CONFIG[eventType].label}: ${dateStr}${isDotConflicted ? ' ⚠️ 重複' : ''}`}
                     />
                   )
                 })}

--- a/components/calendar/SchoolSidebar.tsx
+++ b/components/calendar/SchoolSidebar.tsx
@@ -1,9 +1,12 @@
+// components/calendar/SchoolSidebar.tsx
+import { Trash2 } from 'lucide-react'
 import { Bookmark } from './types'
 
 interface SchoolSidebarProps {
   bookmarks: Bookmark[]
   selectedId: string | null
   onSelect: (id: string | null) => void
+  onDelete: (id: string) => void
 }
 
 const STATUS_LABEL: Record<Bookmark['status'], string> = {
@@ -14,7 +17,7 @@ const STATUS_LABEL: Record<Bookmark['status'], string> = {
   failed: '不合格',
 }
 
-export function SchoolSidebar({ bookmarks, selectedId, onSelect }: SchoolSidebarProps) {
+export function SchoolSidebar({ bookmarks, selectedId, onSelect, onDelete }: SchoolSidebarProps) {
   return (
     <aside className="w-full lg:w-60 shrink-0 bg-bg-card border border-border-custom rounded-2xl overflow-hidden self-start lg:sticky lg:top-6">
       <div className="p-4 border-b border-border-custom">
@@ -41,26 +44,40 @@ export function SchoolSidebar({ bookmarks, selectedId, onSelect }: SchoolSidebar
             : 'bg-badge-private text-badge-private-text'
 
         return (
-          <button
+          <div
             key={b.id}
-            onClick={() => onSelect(isSelected ? null : b.id)}
-            className={`w-full text-left px-4 py-3 transition-colors border-b border-border-custom last:border-b-0 ${
-              isSelected
-                ? 'bg-primary/5 border-l-2 border-l-primary'
-                : 'hover:bg-bg-hover border-l-2 border-l-transparent'
+            className={`group relative border-b border-border-custom last:border-b-0 ${
+              isSelected ? 'bg-primary/5 border-l-2 border-l-primary' : 'hover:bg-bg-hover border-l-2 border-l-transparent'
             }`}
           >
-            <p className={`text-sm font-semibold leading-tight ${isSelected ? 'text-primary' : 'text-text-main'}`}>
-              {b.university_name}
-            </p>
-            <p className="text-text-sub text-xs mt-0.5 truncate">{b.department}</p>
-            <div className="flex items-center gap-1.5 mt-1.5">
-              <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full ${typeColor}`}>
-                {b.type}
-              </span>
-              <span className="text-[10px] text-text-muted">{STATUS_LABEL[b.status]}</span>
-            </div>
-          </button>
+            <button
+              onClick={() => onSelect(isSelected ? null : b.id)}
+              className="w-full text-left px-4 py-3 pr-10 transition-colors"
+            >
+              <p className={`text-sm font-semibold leading-tight ${isSelected ? 'text-primary' : 'text-text-main'}`}>
+                {b.university_name}
+              </p>
+              <p className="text-text-sub text-xs mt-0.5 truncate">{b.department}</p>
+              <div className="flex items-center gap-1.5 mt-1.5">
+                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full ${typeColor}`}>
+                  {b.type}
+                </span>
+                <span className="text-[10px] text-text-muted">{STATUS_LABEL[b.status]}</span>
+              </div>
+            </button>
+
+            {/* 削除ボタン（ホバーで表示） */}
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onDelete(b.id)
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-text-muted hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all"
+              title="削除"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          </div>
         )
       })}
     </aside>

--- a/components/calendar/types.ts
+++ b/components/calendar/types.ts
@@ -41,3 +41,41 @@ export const EVENT_CONFIG: Record<EventType, { label: string; color: string }> =
   interview_date:    { label: '面接日',   color: '#3D6B5A' },
   result_date:       { label: '合格発表', color: '#8B5E3C' },
 }
+
+// DB行の型（user_schedulesテーブル）
+export interface UserScheduleRow {
+  id: string
+  user_id: string
+  university_schedule_id: string | null
+  university_name: string
+  university_name_zh: string | null
+  university_type: string
+  department: string | null
+  application_start: string | null
+  application_end: string | null
+  exam_date: string | null
+  interview_date: string | null
+  result_date: string | null
+  status: string
+  notes: string | null
+  created_at: string
+}
+
+// DB行 → Bookmark型へのマッパー
+export function toBookmark(row: UserScheduleRow): Bookmark {
+  return {
+    id: row.id,
+    university_name: row.university_name,
+    university_name_zh: row.university_name_zh ?? '',
+    department: row.department ?? '',
+    type: (row.university_type as UniversityType) ?? '私立',
+    status: (row.status as BookmarkStatus) ?? 'planning',
+    schedule: {
+      application_start: row.application_start ?? '',
+      application_end: row.application_end ?? '',
+      exam_date: row.exam_date ?? '',
+      interview_date: row.interview_date ?? null,
+      result_date: row.result_date ?? '',
+    },
+  }
+}

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/docs/superpowers/plans/2026-03-31-calendar-auth-ui.md
+++ b/docs/superpowers/plans/2026-03-31-calendar-auth-ui.md
@@ -1,0 +1,1477 @@
+# Calendar Auth & UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Supabase Auth接続・user_schedulesテーブル導入・カレンダーUIの5点改善（ラベル変更・重複ハイライト・削除・追加モーダル）を実装する。
+
+**Architecture:** カレンダーページは'use client'のままSupabaseクライアントで直接データ取得・更新。AuthはSupabase Auth（@supabase/auth-helpers-nextjs）で接続。データはuser_schedulesテーブルに一元化し、既存Bookmark型へのマッパーで各コンポーネントは無変更。
+
+**Tech Stack:** Next.js 16 App Router, TypeScript, Supabase (`@supabase/auth-helpers-nextjs@0.15`), shadcn/ui, Tailwind CSS, pnpm
+
+---
+
+## ファイル変更マップ
+
+| ファイル | 操作 | 理由 |
+|---------|------|------|
+| `supabase/migrations/001_user_schedules.sql` | 新規作成 | user_schedulesテーブル定義 |
+| `lib/supabase/browser.ts` | 新規作成 | ブラウザ用Supabaseクライアント |
+| `lib/supabase/server.ts` | 新規作成 | サーバー用Supabaseクライアント |
+| `lib/supabase.ts` | 維持 | dashboardページが使用中、互換維持 |
+| `components/calendar/types.ts` | 修正 | UserScheduleRow型・toBookmarkマッパー追加 |
+| `components/Navbar.tsx` | 修正 | ラベル変更 + Auth状態表示 |
+| `app/calendar/page.tsx` | 修正 | ラベル変更 + 実データ化 + 認証ガード |
+| `components/calendar/GanttView.tsx` | 修正 | 重複試験日ハイライト追加 |
+| `components/calendar/SchoolSidebar.tsx` | 修正 | 削除ボタン追加 |
+| `components/calendar/AddScheduleModal.tsx` | 新規作成 | 学校追加モーダル（検索+手動入力） |
+| `components/auth/AuthForm.tsx` | 修正 | Supabase Auth実接続 |
+
+---
+
+## Task 1: ラベル変更（クイックウィン）
+
+**Files:**
+- Modify: `components/Navbar.tsx`
+- Modify: `app/calendar/page.tsx`
+
+- [ ] **Step 1: Navbarの「カレンダー」→「マイカレンダー」に変更**
+
+`components/Navbar.tsx` の `navItems` を以下に変更:
+
+```tsx
+const navItems = [
+  { name: "Dashboard", href: "/dashboard", icon: School },
+  { name: "マイカレンダー", href: "/calendar", icon: Calendar },
+  { name: "ログイン", href: "/auth/login", icon: User },
+];
+```
+
+- [ ] **Step 2: カレンダーページのビュー切替ボタンを日本語化**
+
+`app/calendar/page.tsx` の2つのボタンを変更:
+
+```tsx
+// "Timeline" → "一覧"
+<button onClick={() => setActiveView('timeline')} ...>
+  <LayoutList className="w-4 h-4" />
+  一覧
+</button>
+
+// "Gantt" → "年表"
+<button onClick={() => setActiveView('gantt')} ...>
+  <GanttChartSquare className="w-4 h-4" />
+  年表
+</button>
+```
+
+- [ ] **Step 3: 型チェック**
+
+```bash
+cd /Users/zhaojiayi/Desktop/school-search-app && pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add components/Navbar.tsx app/calendar/page.tsx
+git commit -m "feat: ナビ・ビュー切替ボタンを日本語化"
+```
+
+---
+
+## Task 2: DBマイグレーション（user_schedulesテーブル）
+
+**Files:**
+- Create: `supabase/migrations/001_user_schedules.sql`
+
+- [ ] **Step 1: マイグレーションファイルを作成**
+
+```sql
+-- supabase/migrations/001_user_schedules.sql
+
+CREATE TABLE IF NOT EXISTS user_schedules (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 uuid NOT NULL REFERENCES auth.users ON DELETE CASCADE,
+  -- 既存DBから追加した場合（任意）
+  university_schedule_id  uuid REFERENCES university_schedules ON DELETE SET NULL,
+  -- 学校情報（既存連携時はコピー、手動入力時は直接入力）
+  university_name         text NOT NULL,
+  university_name_zh      text,
+  university_type         text NOT NULL DEFAULT '私立'
+    CHECK (university_type IN ('国立', '公立', '私立')),
+  department              text,
+  -- 日程
+  application_start       date,
+  application_end         date,
+  exam_date               date,
+  interview_date          date,
+  result_date             date,
+  -- ステータス
+  status                  text NOT NULL DEFAULT 'planning'
+    CHECK (status IN ('planning', 'applied', 'examined', 'passed', 'failed')),
+  notes                   text,
+  created_at              timestamptz NOT NULL DEFAULT now()
+);
+
+-- RLS
+ALTER TABLE user_schedules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ参照可能"
+  ON user_schedules FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ追加可能"
+  ON user_schedules FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ更新可能"
+  ON user_schedules FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ削除可能"
+  ON user_schedules FOR DELETE
+  USING (auth.uid() = user_id);
+```
+
+- [ ] **Step 2: Supabase SQL EditorでSQLを実行**
+
+Supabaseダッシュボード → SQL Editor → 上記SQLを貼り付けて実行。
+確認: `user_schedules` テーブルがTable Editorに表示されること。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add supabase/migrations/001_user_schedules.sql
+git commit -m "feat: user_schedulesテーブルのマイグレーション追加"
+```
+
+---
+
+## Task 3: Supabaseクライアントユーティリティ
+
+**Files:**
+- Create: `lib/supabase/browser.ts`
+- Create: `lib/supabase/server.ts`
+
+- [ ] **Step 1: ブラウザ用クライアントを作成**
+
+```ts
+// lib/supabase/browser.ts
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+
+export function createBrowserClient() {
+  return createClientComponentClient()
+}
+```
+
+- [ ] **Step 2: サーバー用クライアントを作成**
+
+```ts
+// lib/supabase/server.ts
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+
+export function createServerClient() {
+  return createServerComponentClient({ cookies })
+}
+```
+
+- [ ] **Step 3: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add lib/supabase/browser.ts lib/supabase/server.ts
+git commit -m "feat: Supabaseブラウザ・サーバークライアントユーティリティ追加"
+```
+
+---
+
+## Task 4: Auth接続（AuthForm）
+
+**Files:**
+- Modify: `components/auth/AuthForm.tsx`
+
+- [ ] **Step 1: AuthFormをSupabase Authに接続**
+
+`components/auth/AuthForm.tsx` の `handleSubmit` を以下に置き換える（ファイル全体）:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Mail, Lock, Loader2, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase/browser";
+
+interface AuthFormProps {
+  mode: "login" | "signup";
+}
+
+export function AuthForm({ mode }: AuthFormProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setErrorMsg(null);
+
+    const supabase = createBrowserClient();
+
+    if (mode === "login") {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) {
+        setErrorMsg("メールアドレスまたはパスワードが正しくありません。");
+        setLoading(false);
+        return;
+      }
+    } else {
+      const { error } = await supabase.auth.signUp({ email, password });
+      if (error) {
+        if (error.message.includes("already registered")) {
+          setErrorMsg("このメールアドレスはすでに登録されています。");
+        } else {
+          setErrorMsg("登録に失敗しました。もう一度お試しください。");
+        }
+        setLoading(false);
+        return;
+      }
+    }
+
+    router.push("/calendar");
+    router.refresh();
+  };
+
+  const title = mode === "login" ? "ログイン" : "新規登録";
+  const description =
+    mode === "login"
+      ? "アカウントにログインして、志望校を管理しましょう。"
+      : "アカウントを作成して、受験スケジュールを計画しましょう。";
+
+  return (
+    <div className="min-h-screen bg-bg-main flex flex-col items-center justify-center px-6">
+      <Link
+        href="/dashboard"
+        className="mb-8 flex items-center gap-2 text-text-sub hover:text-primary transition-colors font-bold"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Dashboardに戻る
+      </Link>
+
+      <Card className="w-full max-w-md bg-bg-card border-border-custom rounded-2xl shadow-xl overflow-hidden">
+        <div className="h-2 bg-gradient-to-r from-primary to-accent" />
+
+        <CardHeader className="pt-10 pb-6 text-center">
+          <CardTitle className="text-3xl font-serif text-text-main">{title}</CardTitle>
+          <CardDescription className="text-text-sub mt-2">{description}</CardDescription>
+        </CardHeader>
+
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-6 px-8">
+            {errorMsg && (
+              <p className="text-sm text-destructive bg-destructive/10 rounded-xl px-4 py-3">
+                {errorMsg}
+              </p>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="email" className="text-text-main font-bold">
+                メールアドレス
+              </Label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="name@example.com"
+                  className="pl-10 border-primary/15 rounded-xl focus:border-accent focus:ring-4 focus:ring-accent/10 h-12"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-text-main font-bold">
+                パスワード
+              </Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="••••••••"
+                  className="pl-10 border-primary/15 rounded-xl focus:border-accent focus:ring-4 focus:ring-accent/10 h-12"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  minLength={6}
+                />
+              </div>
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex flex-col gap-6 pt-6 pb-10 px-8">
+            <Button
+              type="submit"
+              className="w-full bg-primary text-white rounded-xl h-12 font-bold hover:opacity-90 shadow-lg"
+              disabled={loading}
+            >
+              {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : title}
+            </Button>
+
+            <div className="text-center text-sm text-text-sub">
+              {mode === "login" ? (
+                <>
+                  アカウントをお持ちでないですか？{" "}
+                  <Link href="/auth/signup" className="text-primary font-bold hover:underline">
+                    新規登録
+                  </Link>
+                </>
+              ) : (
+                <>
+                  既にアカウントをお持ちですか？{" "}
+                  <Link href="/auth/login" className="text-primary font-bold hover:underline">
+                    ログイン
+                  </Link>
+                </>
+              )}
+            </div>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: 動作確認**
+
+1. `pnpm dev` でアプリ起動
+2. `/auth/signup` で新規アカウント作成（テスト用メアド・パスワード6文字以上）
+3. Supabaseダッシュボード → Authentication → Users でユーザーが作成されていることを確認
+4. `/auth/login` でログイン → `/calendar` にリダイレクトされることを確認
+5. 間違ったパスワードでログイン → 日本語エラーメッセージが表示されることを確認
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add components/auth/AuthForm.tsx
+git commit -m "feat: AuthFormをSupabase Authに接続"
+```
+
+---
+
+## Task 5: NavbarにAuth状態を反映
+
+**Files:**
+- Modify: `components/Navbar.tsx`
+
+- [ ] **Step 1: Navbarをファイル全体で置き換え**
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { School, Calendar, User, LogOut } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { createBrowserClient } from "@/lib/supabase/browser";
+import { useEffect, useState } from "react";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+
+export function Navbar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [user, setUser] = useState<SupabaseUser | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getUser().then(({ data }) => setUser(data.user));
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => listener.subscription.unsubscribe();
+  }, []);
+
+  const handleLogout = async () => {
+    const supabase = createBrowserClient();
+    await supabase.auth.signOut();
+    setUser(null);
+    router.push("/dashboard");
+    router.refresh();
+  };
+
+  if (pathname.startsWith("/auth")) return null;
+
+  const navItems = [
+    { name: "Dashboard", href: "/dashboard", icon: School },
+    { name: "マイカレンダー", href: "/calendar", icon: Calendar },
+  ];
+
+  return (
+    <nav className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-white/80 backdrop-blur-lg border border-border-custom rounded-full px-4 py-2 flex items-center gap-2 shadow-2xl z-50 md:top-6 md:bottom-auto md:h-14">
+      <div className="flex items-center gap-1">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all",
+                isActive
+                  ? "bg-primary text-white shadow-md"
+                  : "text-text-sub hover:bg-primary/5 hover:text-primary"
+              )}
+            >
+              <Icon className="w-4 h-4" />
+              <span className="hidden md:inline">{item.name}</span>
+            </Link>
+          );
+        })}
+
+        {user ? (
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold text-text-sub hover:bg-primary/5 hover:text-primary transition-all"
+            title={user.email}
+          >
+            <LogOut className="w-4 h-4" />
+            <span className="hidden md:inline">ログアウト</span>
+          </button>
+        ) : (
+          <Link
+            href="/auth/login"
+            className={cn(
+              "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all",
+              pathname === "/auth/login"
+                ? "bg-primary text-white shadow-md"
+                : "text-text-sub hover:bg-primary/5 hover:text-primary"
+            )}
+          >
+            <User className="w-4 h-4" />
+            <span className="hidden md:inline">ログイン</span>
+          </Link>
+        )}
+      </div>
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: 動作確認**
+
+1. ログイン状態でNavbarに「ログアウト」が表示されることを確認
+2. 未ログイン状態で「ログイン」リンクが表示されることを確認
+3. 「ログアウト」クリック → `/dashboard` にリダイレクトされ、Navbarが「ログイン」に戻ることを確認
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add components/Navbar.tsx
+git commit -m "feat: NavbarにAuth状態（ログイン/ログアウト）を反映"
+```
+
+---
+
+## Task 6: Bookmark型更新（types.tsのみ）
+
+**Files:**
+- Modify: `components/calendar/types.ts`
+
+> **注意:** カレンダーページの実データ化はTask 9（AddScheduleModal作成）の後にTask 10で行う。依存関係の順序を守ること。
+
+- [ ] **Step 1: types.tsにUserScheduleRow型とマッパーを追加**
+
+`components/calendar/types.ts` に以下を追記（既存の型はそのまま維持）:
+
+```ts
+// DB行の型（user_schedulesテーブル）
+export interface UserScheduleRow {
+  id: string
+  user_id: string
+  university_schedule_id: string | null
+  university_name: string
+  university_name_zh: string | null
+  university_type: string
+  department: string | null
+  application_start: string | null
+  application_end: string | null
+  exam_date: string | null
+  interview_date: string | null
+  result_date: string | null
+  status: string
+  notes: string | null
+  created_at: string
+}
+
+// DB行 → Bookmark型へのマッパー
+export function toBookmark(row: UserScheduleRow): Bookmark {
+  return {
+    id: row.id,
+    university_name: row.university_name,
+    university_name_zh: row.university_name_zh ?? '',
+    department: row.department ?? '',
+    type: (row.university_type as UniversityType) ?? '私立',
+    status: (row.status as BookmarkStatus) ?? 'planning',
+    schedule: {
+      application_start: row.application_start ?? '',
+      application_end: row.application_end ?? '',
+      exam_date: row.exam_date ?? '',
+      interview_date: row.interview_date ?? null,
+      result_date: row.result_date ?? '',
+    },
+  }
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし（calendar/page.tsxはまだ変更していないので型エラーは出ない）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add components/calendar/types.ts
+git commit -m "feat: UserScheduleRow型とtoBookmarkマッパーをtypes.tsに追加"
+```
+
+---
+
+## Task 7: GanttViewに重複ハイライト追加
+
+**Files:**
+- Modify: `components/calendar/GanttView.tsx`
+
+- [ ] **Step 1: GanttViewに重複検出ロジックとハイライトを追加**
+
+`components/calendar/GanttView.tsx` を以下のように修正（`getConflictedIds` 関数と表示を追加）:
+
+`GanttViewProps` の直後、`getDateRange` の前に追加:
+
+```ts
+// exam_dateが重複しているbookmarkIdのセット
+function getConflictedIds(bookmarks: Bookmark[]): Set<string> {
+  const dateCounts: Record<string, string[]> = {}
+  for (const b of bookmarks) {
+    const d = b.schedule.exam_date
+    if (!d) continue
+    if (!dateCounts[d]) dateCounts[d] = []
+    dateCounts[d].push(b.id)
+  }
+  const conflicted = new Set<string>()
+  for (const ids of Object.values(dateCounts)) {
+    if (ids.length > 1) ids.forEach((id) => conflicted.add(id))
+  }
+  return conflicted
+}
+```
+
+`GanttView` 関数内、`getDateRange` 呼び出しの直後に追加:
+
+```ts
+const conflictedIds = getConflictedIds(bookmarks)
+```
+
+各学校行の `div` にクラスを追加（`isDimmed` の後）:
+
+```tsx
+const isConflicted = conflictedIds.has(b.id)
+
+<div
+  key={b.id}
+  className={`flex items-center gap-2 mb-3 transition-opacity duration-200 ${
+    isDimmed ? 'opacity-30' : 'opacity-100'
+  }`}
+>
+```
+
+`exam_date` ポイントイベントのdotに重複ハイライトを追加（`POINT_EVENTS.map` 内）:
+
+```tsx
+{POINT_EVENTS.map((eventType) => {
+  const dateStr = b.schedule[eventType]
+  if (!dateStr) return null
+  const isDotConflicted = eventType === 'exam_date' && isConflicted
+  return (
+    <div
+      key={eventType}
+      className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm ${
+        isDotConflicted ? 'ring-2 ring-destructive ring-offset-1' : ''
+      }`}
+      style={{
+        left: `${toPct(dateStr)}%`,
+        backgroundColor: isDotConflicted
+          ? '#AF4448'
+          : EVENT_CONFIG[eventType].color,
+      }}
+      title={`${EVENT_CONFIG[eventType].label}: ${dateStr}${isDotConflicted ? ' ⚠️ 重複' : ''}`}
+    />
+  )
+})}
+```
+
+学校名エリア（`w-44 shrink-0 pr-3 text-right` のdiv）に重複アイコンを追加:
+
+```tsx
+<div className="w-44 shrink-0 pr-3 text-right">
+  <div className="flex items-center justify-end gap-1">
+    {isConflicted && (
+      <AlertTriangle className="w-3.5 h-3.5 text-destructive shrink-0" />
+    )}
+    <p className="text-sm font-semibold text-text-main leading-tight truncate">
+      {b.university_name}
+    </p>
+  </div>
+  <p className="text-[10px] text-text-sub truncate">{b.department}</p>
+</div>
+```
+
+ファイル先頭のimportに `AlertTriangle` を追加:
+
+```ts
+import { differenceInCalendarDays, parseISO, format, addDays } from 'date-fns'
+import { AlertTriangle } from 'lucide-react'
+import { Bookmark, EVENT_CONFIG } from './types'
+```
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add components/calendar/GanttView.tsx
+git commit -m "feat: GanttViewに重複試験日ハイライト追加"
+```
+
+---
+
+## Task 8: 学校削除機能
+
+**Files:**
+- Modify: `components/calendar/SchoolSidebar.tsx`
+
+- [ ] **Step 1: SchoolSidebarに削除ボタンを追加（ファイル全体を置き換え）**
+
+```tsx
+// components/calendar/SchoolSidebar.tsx
+import { Trash2 } from 'lucide-react'
+import { Bookmark } from './types'
+
+interface SchoolSidebarProps {
+  bookmarks: Bookmark[]
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+  onDelete: (id: string) => void
+}
+
+const STATUS_LABEL: Record<Bookmark['status'], string> = {
+  planning: '検討中',
+  applied: '出願済',
+  examined: '受験済',
+  passed: '合格',
+  failed: '不合格',
+}
+
+export function SchoolSidebar({ bookmarks, selectedId, onSelect, onDelete }: SchoolSidebarProps) {
+  return (
+    <aside className="w-full lg:w-60 shrink-0 bg-bg-card border border-border-custom rounded-2xl overflow-hidden self-start lg:sticky lg:top-6">
+      <div className="p-4 border-b border-border-custom">
+        <h2 className="text-text-main font-bold text-sm">大学名称</h2>
+      </div>
+
+      {/* 全て表示ボタン */}
+      <button
+        onClick={() => onSelect(null)}
+        className={`w-full text-left px-4 py-3 text-sm font-medium transition-colors border-b border-border-custom ${
+          selectedId === null
+            ? 'bg-primary/5 text-primary border-l-2 border-l-primary'
+            : 'text-text-sub hover:bg-bg-hover border-l-2 border-l-transparent'
+        }`}
+      >
+        すべて表示
+      </button>
+
+      {bookmarks.map((b) => {
+        const isSelected = selectedId === b.id
+        const typeColor =
+          b.type === '国立' || b.type === '公立'
+            ? 'bg-badge-public text-badge-public-text'
+            : 'bg-badge-private text-badge-private-text'
+
+        return (
+          <div
+            key={b.id}
+            className={`group relative border-b border-border-custom last:border-b-0 ${
+              isSelected ? 'bg-primary/5 border-l-2 border-l-primary' : 'hover:bg-bg-hover border-l-2 border-l-transparent'
+            }`}
+          >
+            <button
+              onClick={() => onSelect(isSelected ? null : b.id)}
+              className="w-full text-left px-4 py-3 pr-10 transition-colors"
+            >
+              <p className={`text-sm font-semibold leading-tight ${isSelected ? 'text-primary' : 'text-text-main'}`}>
+                {b.university_name}
+              </p>
+              <p className="text-text-sub text-xs mt-0.5 truncate">{b.department}</p>
+              <div className="flex items-center gap-1.5 mt-1.5">
+                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full ${typeColor}`}>
+                  {b.type}
+                </span>
+                <span className="text-[10px] text-text-muted">{STATUS_LABEL[b.status]}</span>
+              </div>
+            </button>
+
+            {/* 削除ボタン（ホバーで表示） */}
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onDelete(b.id)
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-text-muted hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all"
+              title="削除"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        )
+      })}
+    </aside>
+  )
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし（`onDelete` プロパティはTask 6のpage.tsxで渡している）
+
+- [ ] **Step 3: 動作確認**
+
+1. カレンダーページでユーザーデータがある状態でサイドバーの学校にホバー
+2. ゴミ箱アイコンが表示されることを確認
+3. クリックで学校が一覧から消えることを確認
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add components/calendar/SchoolSidebar.tsx
+git commit -m "feat: サイドバーに学校削除ボタン追加"
+```
+
+---
+
+## Task 9: 学校追加モーダル
+
+**Files:**
+- Create: `components/calendar/AddScheduleModal.tsx`
+
+- [ ] **Step 1: AddScheduleModalを作成**
+
+```tsx
+// components/calendar/AddScheduleModal.tsx
+'use client'
+
+import { useState } from 'react'
+import { X, Search, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { createBrowserClient } from '@/lib/supabase/browser'
+
+interface AddScheduleModalProps {
+  onClose: () => void
+  onAdded: () => void
+}
+
+type Tab = 'search' | 'manual'
+
+interface UniversityResult {
+  id: string
+  name_ja: string
+  name_zh: string
+  type: string
+  departments: string[]
+}
+
+interface ScheduleResult {
+  id: string
+  department: string
+  application_start: string | null
+  application_end: string | null
+  exam_date: string | null
+  interview_date: string | null
+  result_date: string | null
+}
+
+export function AddScheduleModal({ onClose, onAdded }: AddScheduleModalProps) {
+  const [tab, setTab] = useState<Tab>('search')
+
+  // 検索タブ用のstate
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<UniversityResult[]>([])
+  const [selectedUniversity, setSelectedUniversity] = useState<UniversityResult | null>(null)
+  const [schedules, setSchedules] = useState<ScheduleResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const [adding, setAdding] = useState(false)
+
+  // 手動入力タブ用のstate
+  const [manual, setManual] = useState({
+    university_name: '',
+    university_name_zh: '',
+    university_type: '私立',
+    department: '',
+    application_start: '',
+    application_end: '',
+    exam_date: '',
+    interview_date: '',
+    result_date: '',
+  })
+
+  const handleSearch = async (query: string) => {
+    setSearchQuery(query)
+    if (query.length < 1) {
+      setSearchResults([])
+      return
+    }
+    setSearching(true)
+    const supabase = createBrowserClient()
+    const { data } = await supabase
+      .from('universities')
+      .select('id, name_ja, name_zh, type, departments')
+      .or(`name_ja.ilike.%${query}%,name_zh.ilike.%${query}%`)
+      .limit(8)
+    setSearchResults(
+      (data ?? []).map((u) => ({
+        ...u,
+        departments: Array.isArray(u.departments) ? u.departments : [],
+      }))
+    )
+    setSearching(false)
+  }
+
+  const handleSelectUniversity = async (uni: UniversityResult) => {
+    setSelectedUniversity(uni)
+    setSearchResults([])
+    setSearchQuery(uni.name_ja)
+    const supabase = createBrowserClient()
+    const { data } = await supabase
+      .from('university_schedules')
+      .select('id, department, application_start, application_end, exam_date, interview_date, result_date')
+      .eq('university_id', uni.id)
+    setSchedules(data ?? [])
+  }
+
+  const handleAddFromSearch = async (schedule: ScheduleResult) => {
+    if (!selectedUniversity) return
+    setAdding(true)
+    const supabase = createBrowserClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return
+
+    await supabase.from('user_schedules').insert({
+      user_id: user.id,
+      university_schedule_id: schedule.id,
+      university_name: selectedUniversity.name_ja,
+      university_name_zh: selectedUniversity.name_zh,
+      university_type: selectedUniversity.type,
+      department: schedule.department,
+      application_start: schedule.application_start,
+      application_end: schedule.application_end,
+      exam_date: schedule.exam_date,
+      interview_date: schedule.interview_date,
+      result_date: schedule.result_date,
+    })
+    setAdding(false)
+    onAdded()
+  }
+
+  const handleAddManual = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!manual.university_name) return
+    setAdding(true)
+    const supabase = createBrowserClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return
+
+    await supabase.from('user_schedules').insert({
+      user_id: user.id,
+      university_name: manual.university_name,
+      university_name_zh: manual.university_name_zh || null,
+      university_type: manual.university_type,
+      department: manual.department || null,
+      application_start: manual.application_start || null,
+      application_end: manual.application_end || null,
+      exam_date: manual.exam_date || null,
+      interview_date: manual.interview_date || null,
+      result_date: manual.result_date || null,
+    })
+    setAdding(false)
+    onAdded()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* オーバーレイ */}
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" onClick={onClose} />
+
+      {/* モーダル本体 */}
+      <div className="relative bg-bg-card border border-border-custom rounded-2xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between p-6 border-b border-border-custom">
+          <h2 className="text-xl font-serif text-text-main">学校を追加</h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-xl text-text-muted hover:bg-primary/5 hover:text-primary transition-all"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* タブ切替 */}
+        <div className="flex border-b border-border-custom">
+          <button
+            onClick={() => setTab('search')}
+            className={`flex-1 py-3 text-sm font-bold transition-all ${
+              tab === 'search'
+                ? 'text-primary border-b-2 border-primary'
+                : 'text-text-sub hover:text-text-main'
+            }`}
+          >
+            データベースから検索
+          </button>
+          <button
+            onClick={() => setTab('manual')}
+            className={`flex-1 py-3 text-sm font-bold transition-all ${
+              tab === 'manual'
+                ? 'text-primary border-b-2 border-primary'
+                : 'text-text-sub hover:text-text-main'
+            }`}
+          >
+            手動で入力
+          </button>
+        </div>
+
+        <div className="p-6">
+          {/* 検索タブ */}
+          {tab === 'search' && (
+            <div className="space-y-4">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                <Input
+                  placeholder="大学名を入力..."
+                  className="pl-10 border-primary/15 rounded-xl h-11"
+                  value={searchQuery}
+                  onChange={(e) => handleSearch(e.target.value)}
+                />
+                {searching && (
+                  <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted animate-spin" />
+                )}
+              </div>
+
+              {/* 検索候補 */}
+              {searchResults.length > 0 && (
+                <div className="border border-border-custom rounded-xl overflow-hidden">
+                  {searchResults.map((uni) => (
+                    <button
+                      key={uni.id}
+                      onClick={() => handleSelectUniversity(uni)}
+                      className="w-full text-left px-4 py-3 hover:bg-bg-hover transition-colors border-b border-border-custom last:border-b-0"
+                    >
+                      <p className="text-sm font-semibold text-text-main">{uni.name_ja}</p>
+                      <p className="text-xs text-text-sub">{uni.name_zh} · {uni.type}</p>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* 選択された大学の日程一覧 */}
+              {selectedUniversity && schedules.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-sm font-bold text-text-main">
+                    {selectedUniversity.name_ja} の日程
+                  </p>
+                  {schedules.map((s) => (
+                    <div
+                      key={s.id}
+                      className="bg-primary/5 border border-primary/10 rounded-xl p-3 space-y-1"
+                    >
+                      <p className="text-sm font-bold text-text-main">{s.department}</p>
+                      {s.exam_date && (
+                        <p className="text-xs text-text-sub">試験日: {s.exam_date}</p>
+                      )}
+                      {s.application_end && (
+                        <p className="text-xs text-text-sub">出願締切: {s.application_end}</p>
+                      )}
+                      <Button
+                        onClick={() => handleAddFromSearch(s)}
+                        disabled={adding}
+                        className="mt-2 w-full bg-primary text-white rounded-xl h-9 text-sm font-bold hover:opacity-90"
+                      >
+                        {adding ? <Loader2 className="w-4 h-4 animate-spin" /> : '追加する'}
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {selectedUniversity && schedules.length === 0 && (
+                <p className="text-sm text-text-muted text-center py-4">
+                  この大学の日程データはまだ登録されていません。<br />
+                  「手動で入力」タブから追加してください。
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* 手動入力タブ */}
+          {tab === 'manual' && (
+            <form onSubmit={handleAddManual} className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">
+                  学校名 <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  placeholder="例：東京大学"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.university_name}
+                  onChange={(e) => setManual({ ...manual, university_name: e.target.value })}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">学校名（中国語）</Label>
+                <Input
+                  placeholder="例：东京大学"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.university_name_zh}
+                  onChange={(e) => setManual({ ...manual, university_name_zh: e.target.value })}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">種別</Label>
+                <div className="flex gap-2">
+                  {(['国立', '公立', '私立'] as const).map((t) => (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => setManual({ ...manual, university_type: t })}
+                      className={`flex-1 py-2 rounded-xl text-sm font-bold transition-all ${
+                        manual.university_type === t
+                          ? 'bg-primary text-white'
+                          : 'bg-primary/5 text-primary hover:bg-primary/10'
+                      }`}
+                    >
+                      {t}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">研究科</Label>
+                <Input
+                  placeholder="例：工学系研究科"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.department}
+                  onChange={(e) => setManual({ ...manual, department: e.target.value })}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">出願開始日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.application_start}
+                    onChange={(e) => setManual({ ...manual, application_start: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">出願締切日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.application_end}
+                    onChange={(e) => setManual({ ...manual, application_end: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">試験日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.exam_date}
+                    onChange={(e) => setManual({ ...manual, exam_date: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-text-main font-bold text-sm">面接日</Label>
+                  <Input
+                    type="date"
+                    className="border-primary/15 rounded-xl h-11"
+                    value={manual.interview_date}
+                    onChange={(e) => setManual({ ...manual, interview_date: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-text-main font-bold text-sm">合格発表日</Label>
+                <Input
+                  type="date"
+                  className="border-primary/15 rounded-xl h-11"
+                  value={manual.result_date}
+                  onChange={(e) => setManual({ ...manual, result_date: e.target.value })}
+                />
+              </div>
+
+              <Button
+                type="submit"
+                disabled={adding || !manual.university_name}
+                className="w-full bg-primary text-white rounded-xl h-12 font-bold hover:opacity-90 shadow-md mt-2"
+              >
+                {adding ? <Loader2 className="w-5 h-5 animate-spin" /> : '追加する'}
+              </Button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: ESLintチェック**
+
+```bash
+pnpm lint
+```
+
+Expected: エラーなし（警告は許容）
+
+- [ ] **Step 4: 動作確認**
+
+1. ログイン状態でカレンダーページを開く
+2. 「学校を追加」ボタンをクリック → モーダルが表示されることを確認
+3. **検索タブ**: 「東京」と入力 → 大学候補が表示 → 選択 → 研究科一覧が表示 → 「追加する」
+4. Supabaseダッシュボード → Table Editor → `user_schedules` にレコードが追加されていることを確認
+5. カレンダーページに追加した学校が表示されることを確認
+6. **手動入力タブ**: 学校名・日程を入力 → 「追加する」 → リストに反映されることを確認
+7. サイドバーの学校にホバー → ゴミ箱アイコンをクリック → 削除されることを確認
+8. 試験日が重複する2校を追加 → ConflictBannerが表示され、GanttViewの該当ドットに赤リングが表示されることを確認
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add components/calendar/AddScheduleModal.tsx
+git commit -m "feat: 学校追加モーダル（DBから検索・手動入力）を追加"
+```
+
+---
+
+## Task 10: カレンダーページ — 実データ化・認証ガード・モーダル統合
+
+**Files:**
+- Modify: `app/calendar/page.tsx`
+
+> **前提:** Task 8（SchoolSidebar onDelete）とTask 9（AddScheduleModal）が完了していること。
+
+- [ ] **Step 1: カレンダーページをファイル全体で置き換え**
+
+```tsx
+// app/calendar/page.tsx
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { CalendarIcon, LayoutList, GanttChartSquare, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { SchoolSidebar } from '@/components/calendar/SchoolSidebar'
+import { TimelineView } from '@/components/calendar/TimelineView'
+import { GanttView } from '@/components/calendar/GanttView'
+import { ConflictBanner } from '@/components/calendar/ConflictBanner'
+import { AddScheduleModal } from '@/components/calendar/AddScheduleModal'
+import { toBookmark } from '@/components/calendar/types'
+import type { Bookmark, ViewType, UserScheduleRow } from '@/components/calendar/types'
+import { createBrowserClient } from '@/lib/supabase/browser'
+
+export default function CalendarPage() {
+  const router = useRouter()
+  const [activeView, setActiveView] = useState<ViewType>('timeline')
+  const [selectedSchoolId, setSelectedSchoolId] = useState<string | null>(null)
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAddModal, setShowAddModal] = useState(false)
+
+  const fetchBookmarks = async () => {
+    const supabase = createBrowserClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    if (!user) {
+      router.push('/auth/login')
+      return
+    }
+
+    const { data } = await supabase
+      .from('user_schedules')
+      .select('*')
+      .order('created_at', { ascending: false })
+
+    setBookmarks((data as UserScheduleRow[] ?? []).map(toBookmark))
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchBookmarks()
+  }, [])
+
+  const handleDelete = async (id: string) => {
+    const supabase = createBrowserClient()
+    await supabase.from('user_schedules').delete().eq('id', id)
+    setBookmarks((prev) => prev.filter((b) => b.id !== id))
+    if (selectedSchoolId === id) setSelectedSchoolId(null)
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-bg-main flex items-center justify-center">
+        <p className="text-text-sub">読み込み中...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-main py-10 px-6">
+      <div className="max-w-6xl mx-auto">
+
+        {/* ヘッダー */}
+        <header className="mb-8 flex flex-col sm:flex-row justify-between items-start sm:items-end gap-4">
+          <div>
+            <div className="inline-flex items-center gap-2 bg-primary/5 text-primary rounded-full px-4 py-2 text-sm font-bold mb-4">
+              <CalendarIcon className="w-4 h-4" />
+              <span>マイカレンダー</span>
+            </div>
+            <h1 className="text-4xl font-serif text-text-main">受験スケジュール</h1>
+            <p className="text-text-sub mt-2">志望校の日程を確認し、重複をチェックしましょう。</p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <div className="flex items-center bg-bg-card border border-border-custom rounded-xl p-1 gap-1">
+              <button
+                onClick={() => setActiveView('timeline')}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                  activeView === 'timeline'
+                    ? 'bg-primary text-white shadow-sm'
+                    : 'text-text-sub hover:text-text-main'
+                }`}
+              >
+                <LayoutList className="w-4 h-4" />
+                一覧
+              </button>
+              <button
+                onClick={() => setActiveView('gantt')}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                  activeView === 'gantt'
+                    ? 'bg-primary text-white shadow-sm'
+                    : 'text-text-sub hover:text-text-main'
+                }`}
+              >
+                <GanttChartSquare className="w-4 h-4" />
+                年表
+              </button>
+            </div>
+
+            <Button
+              onClick={() => setShowAddModal(true)}
+              className="bg-primary text-white rounded-xl font-bold px-5 h-10 shadow-md hover:opacity-90 transition-all flex items-center gap-2"
+            >
+              <Plus className="w-4 h-4" />
+              学校を追加
+            </Button>
+          </div>
+        </header>
+
+        {/* 重複警告バナー */}
+        <ConflictBanner bookmarks={bookmarks} />
+
+        {/* メインコンテンツ */}
+        {bookmarks.length === 0 ? (
+          <div className="text-center py-32 bg-bg-card rounded-3xl border border-dashed border-border-custom">
+            <CalendarIcon className="w-16 h-16 text-text-muted mx-auto mb-6" />
+            <h3 className="text-xl font-serif text-text-main">カレンダーは空です</h3>
+            <p className="text-text-sub mt-2 mb-8">志望校を追加してスケジュールを管理しましょう。</p>
+            <Button
+              onClick={() => setShowAddModal(true)}
+              className="bg-primary text-white rounded-xl font-bold px-8 h-12 shadow-lg"
+            >
+              学校を追加する
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col lg:flex-row gap-6 items-start">
+            <SchoolSidebar
+              bookmarks={bookmarks}
+              selectedId={selectedSchoolId}
+              onSelect={setSelectedSchoolId}
+              onDelete={handleDelete}
+            />
+            <div className="flex-1 bg-bg-card border border-border-custom rounded-2xl p-6 min-h-[600px] flex flex-col">
+              {activeView === 'timeline' ? (
+                <TimelineView bookmarks={bookmarks} selectedId={selectedSchoolId} />
+              ) : (
+                <GanttView bookmarks={bookmarks} selectedId={selectedSchoolId} />
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showAddModal && (
+        <AddScheduleModal
+          onClose={() => setShowAddModal(false)}
+          onAdded={() => {
+            setShowAddModal(false)
+            fetchBookmarks()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: ESLintチェック**
+
+```bash
+pnpm lint
+```
+
+Expected: エラーなし
+
+- [ ] **Step 4: 動作確認**
+
+1. ログイン状態でカレンダーページを開く → 実データが表示されることを確認
+2. 未ログインでカレンダーページにアクセス → `/auth/login` にリダイレクトされることを確認
+3. 「学校を追加」ボタンをクリック → モーダルが表示されることを確認
+4. 検索タブ・手動入力タブが切り替えられることを確認
+5. 学校を追加後にリストに反映されることを確認
+6. 削除ボタンで学校が消えることを確認
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/calendar/page.tsx
+git commit -m "feat: カレンダーページを実データ化・認証ガード・追加モーダル統合"
+```
+
+---
+
+## 最終確認
+
+- [ ] **全体の型チェック**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: エラーなし
+
+- [ ] **ESLint**
+
+```bash
+pnpm lint
+```
+
+Expected: エラーなし
+
+- [ ] **最終動作確認チェックリスト**
+
+- [ ] Navbarに「マイカレンダー」と表示されている
+- [ ] ビュー切替ボタンが「一覧」「年表」と表示されている
+- [ ] ログイン/ログアウトがNavbarで正しく切り替わる
+- [ ] 未ログインでカレンダーページにアクセスするとログインページに遷移する
+- [ ] ログイン後にカレンダーページでユーザーのデータが表示される
+- [ ] 学校を追加（DB検索）できる
+- [ ] 学校を追加（手動入力）できる
+- [ ] 学校を削除できる
+- [ ] 試験日が重複するとConflictBannerと年表ハイライトが表示される

--- a/docs/superpowers/specs/2026-03-31-calendar-auth-ui-design.md
+++ b/docs/superpowers/specs/2026-03-31-calendar-auth-ui-design.md
@@ -1,0 +1,185 @@
+# GO院 — カレンダー・認証・UI改善 設計仕様書
+
+**作成日:** 2026-03-31
+**スコープ:** Auth接続 / user_schedulesテーブル / カレンダーUI5点改善
+
+---
+
+## 1. 概要
+
+現在モックデータで動いているカレンダーページをSupabase実データに切り替え、Auth接続を完成させる。あわせてカレンダーUIの5つの問題点を修正する。
+
+AI（URL/PDF読み込み）機能は今回のスコープ外。後フェーズで追加する。
+
+---
+
+## 2. データベース変更
+
+### 2-1. user_bookmarks → user_schedules に置き換え
+
+既存の `user_bookmarks`（schedule_idのみ保持）では手動入力に対応できないため、`user_schedules` テーブルに移行する。
+
+```sql
+CREATE TABLE user_schedules (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 uuid NOT NULL REFERENCES auth.users ON DELETE CASCADE,
+  -- 既存DBから追加した場合（任意）
+  university_schedule_id  uuid REFERENCES university_schedules ON DELETE SET NULL,
+  -- 表示用フィールド（既存連携時はコピー、手動入力時は直接入力）
+  university_name         text NOT NULL,
+  department              text,
+  application_start       date,
+  application_end         date,
+  exam_date               date,
+  interview_date          date,
+  result_date             date,
+  -- ステータス管理
+  status                  text DEFAULT 'planning'
+    CHECK (status IN ('planning','applied','examined','passed','failed')),
+  notes                   text,
+  created_at              timestamptz DEFAULT now()
+);
+```
+
+**データ種別の判定:**
+- `university_schedule_id IS NOT NULL` → 既存DBから追加
+- `university_schedule_id IS NULL` → 手動入力
+
+### 2-2. RLSポリシー
+
+```sql
+ALTER TABLE user_schedules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ操作可能"
+  ON user_schedules FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+```
+
+---
+
+## 3. Auth接続
+
+### 3-1. AuthForm（login / signup）
+
+`components/auth/AuthForm.tsx` の `handleSubmit` を実装する。
+
+- **ログイン:** `supabase.auth.signInWithPassword({ email, password })`
+- **新規登録:** `supabase.auth.signUp({ email, password })`
+- エラー時はフォーム内にエラーメッセージを表示（日本語）
+- 成功時は `/calendar` にリダイレクト
+
+### 3-2. Navbar のAuth状態反映
+
+`components/Navbar.tsx` にAuth状態を追加する。
+
+- **未ログイン:** 「ログイン」リンクを表示（現状通り）
+- **ログイン済み:** ユーザーアイコン（アバター）＋「ログアウト」ボタンを表示
+- `supabase.auth.getUser()` でクライアント側のセッションを取得
+- ログアウトは `supabase.auth.signOut()` → `/dashboard` へリダイレクト
+
+### 3-3. カレンダーページのAuth保護
+
+`app/calendar/page.tsx` でセッションチェックを行う。
+
+- 未ログイン → `/auth/login?redirect=/calendar` にリダイレクト
+- ログイン済み → Supabaseから `user_schedules` を取得して表示
+
+---
+
+## 4. UI改善（5点）
+
+### 4-1. Navbar ラベル変更
+
+`components/Navbar.tsx`:
+- 「カレンダー」→「マイカレンダー」
+
+### 4-2. ビュー切替ボタンを日本語化
+
+`app/calendar/page.tsx`:
+- "Timeline" → 「一覧」
+- "Gantt" → 「年表」
+
+### 4-3. 重複試験日のビジュアルハイライト
+
+現状はバナーで通知するのみ。該当イベントを視覚的にマークする。
+
+**実装方針:**
+- `ConflictBanner` が検出している重複ロジックを共通ユーティリティ（`utils.ts`）に切り出す
+- `TimelineView` と `GanttView` で、`exam_date` が重複しているエントリに対して:
+  - 赤系のボーダー（`border-red-400`）
+  - ⚠️アイコン（`AlertTriangle` from lucide-react）をイベントカードに追加
+
+### 4-4. 学校削除機能
+
+`components/calendar/SchoolSidebar.tsx` の各学校カードに削除ボタンを追加。
+
+- ゴミ箱アイコン（`Trash2` from lucide-react）
+- クリック時に確認なしで即削除（モックデータ段階では `useState` で管理、実データ連携後は Supabase DELETE）
+- Server Action: `deleteUserSchedule(id: string)`
+
+### 4-5. 学校追加モーダル
+
+「学校を追加する」ボタンをクリックすると、Dashboardへの遷移ではなくモーダルを表示。
+
+**モーダル構成（2タブ）:**
+
+**タブA: 既存DBから検索**
+- テキスト入力でオートコンプリート（`universities` テーブルを検索）
+- 候補を選択すると研究科一覧が表示
+- 研究科を選択すると日程が自動入力される
+- 「追加」ボタンで `user_schedules` にINSERT
+
+**タブB: 手動入力**
+| フィールド | 型 | 必須 |
+|-----------|----|----|
+| 学校名 | text | ✓ |
+| 研究科 | text | - |
+| 出願開始日 | date | - |
+| 出願締切日 | date | - |
+| 試験日 | date | - |
+| 面接日 | date | - |
+| 合格発表日 | date | - |
+
+- 「追加」ボタンで `user_schedules` にINSERT（`university_schedule_id` はNULL）
+
+**モーダルコンポーネント:** `components/calendar/AddScheduleModal.tsx`（新規作成）
+
+---
+
+## 5. データフロー
+
+```
+カレンダーページ起動
+  ↓
+セッションチェック（クライアント側）
+  ├─ 未ログイン → /auth/login にリダイレクト
+  └─ ログイン済み
+       ↓
+  user_schedules を user_id でフェッチ
+       ↓
+  重複チェック（exam_dateが被るエントリを検出）
+       ↓
+  ConflictBanner + TimelineView/GanttView（ハイライト付き）に渡す
+```
+
+---
+
+## 6. スコープ外（後フェーズ）
+
+- URL/PDF読み込みによるAI自動入力
+- SchoolCard の「カレンダーに追加」ボタンの実動作（現在はログインページへリダイレクト）
+- user_bookmarks テーブルの削除（移行後）
+
+---
+
+## 7. 実装順序
+
+1. DBマイグレーション（`user_schedules` テーブル作成 + RLS）
+2. Auth接続（AuthForm → Supabase Auth）
+3. Navbar Auth状態反映
+4. カレンダーページ実データ化（`user_schedules` フェッチ）
+5. UI改善①② ラベル変更（簡単なので先にやる）
+6. 重複ハイライト（④-3）
+7. 削除機能（④-4）
+8. 追加モーダル（④-5、最も複雑）

--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,0 +1,10 @@
+// lib/supabase/browser.ts
+// ブラウザ（Client Component）用Supabaseクライアント
+import { createBrowserClient as _createBrowserClient } from '@supabase/auth-helpers-nextjs'
+
+export function createBrowserClient() {
+  return _createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+  )
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,28 @@
+// lib/supabase/server.ts
+// サーバー（Server Component）用Supabaseクライアント
+import { createServerClient as _createServerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+
+export async function createServerClient() {
+  const cookieStore = await cookies()
+  return _createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          } catch {
+            // Server Componentからの呼び出しではsetは無視される
+          }
+        },
+      },
+    }
+  )
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
+    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       next:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -2245,6 +2248,12 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.2.1:
     resolution: {integrity: sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==}
@@ -5289,6 +5298,11 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/supabase/migrations/001_user_schedules.sql
+++ b/supabase/migrations/001_user_schedules.sql
@@ -1,0 +1,49 @@
+-- =============================================
+-- user_schedulesテーブル（ユーザーのマイカレンダー）
+-- =============================================
+-- 既存DBから追加した学校も、手動入力した学校も一元管理する
+-- university_schedule_id IS NOT NULL → 既存DBから追加
+-- university_schedule_id IS NULL     → 手動入力
+
+CREATE TABLE IF NOT EXISTS user_schedules (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 uuid NOT NULL REFERENCES auth.users ON DELETE CASCADE,
+  -- 既存DBから追加した場合（任意）
+  university_schedule_id  uuid REFERENCES university_schedules ON DELETE SET NULL,
+  -- 学校情報（既存連携時はコピー、手動入力時は直接入力）
+  university_name         text NOT NULL,
+  university_name_zh      text,
+  university_type         text NOT NULL DEFAULT '私立'
+    CHECK (university_type IN ('国立', '公立', '私立')),
+  department              text,
+  -- 日程
+  application_start       date,
+  application_end         date,
+  exam_date               date,
+  interview_date          date,
+  result_date             date,
+  -- ステータス
+  status                  text NOT NULL DEFAULT 'planning'
+    CHECK (status IN ('planning', 'applied', 'examined', 'passed', 'failed')),
+  notes                   text,
+  created_at              timestamptz NOT NULL DEFAULT now()
+);
+
+-- RLS
+ALTER TABLE user_schedules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ参照可能"
+  ON user_schedules FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ追加可能"
+  ON user_schedules FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ更新可能"
+  ON user_schedules FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "ユーザーは自分のスケジュールのみ削除可能"
+  ON user_schedules FOR DELETE
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/001_user_schedules.sql
+++ b/supabase/migrations/001_user_schedules.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS user_schedules (
   university_name         text NOT NULL,
   university_name_zh      text,
   university_type         text NOT NULL DEFAULT '私立'
-    CHECK (university_type IN ('国立', '公立', '私立')),
+    CHECK (university_type IN ('国立', '公立', '私立', '国公立')),
   department              text,
   -- 日程
   application_start       date,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE universities (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   name_ja TEXT NOT NULL,
   name_zh TEXT NOT NULL,
-  type TEXT CHECK (type IN ('国立', '公立', '私立')) NOT NULL,
+  type TEXT CHECK (type IN ('国立', '公立', '私立', '国公立')) NOT NULL,
   departments JSONB DEFAULT '[]'::jsonb,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );


### PR DESCRIPTION
## 概要
アプリケーションにテーマ切り替え機能を導入しました。ブランドのアイデンティティを保ちつつ、ユーザーの好みに合わせた3つの表示モードを提供します。

## 主な変更点
- **globals.css**: `[data-theme]` 属性に基づいたカラー変数の定義（Sepia, Light, Dark）。
- **layout.tsx**: `ThemeProvider` によるアプリケーションのラップ。
- **components/theme-provider.tsx**: `next-themes` の `ThemeProvider` をラップしたクライアントコンポーネント。
- **components/Navbar.tsx**: テーマ切り替えボタンと選択メニューの追加。
- **UI改善**: 全テーマでブランドの一貫性を保つため、アクセントカラーを茶色系統に統一。

## 動作確認
- [x] テーマ切り替えボタンから各モード（Sepia, Light, Dark）に正常に切り替わること。
- [x] リロード後も選択したテーマが保持されること。
- [x] 各モードでテキストやボタンの視認性が確保されていること。
- [x] カラーチップの表示が背景と同化せず、正しく視認できること。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User authentication with sign-in and sign-up functionality
  * Personal calendar backed by user data (replaces mock data)
  * Schedule management: add schedules via search or manual entry, delete existing schedules
  * Schedule conflict detection with visual warnings for duplicate exam dates
  * Theme customization with Sepia, Light, and Dark modes

* **UI Improvements**
  * Localized interface labels in Japanese
  * Theme selector in navigation bar
  * Real-time highlighting of conflicting exam dates in calendar views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->